### PR TITLE
Make installs and release updates preserve user state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Host directories must already exist. Crowbarr never changes media ownership.
+CROWBARR_CONFIG_DIR=/srv/crowbarr/config
+CROWBARR_MEDIA_DIR=/srv/media
+CROWBARR_UID=1000
+CROWBARR_GID=1000
+CROWBARR_PORT=8449
+# Container paths must stay the same when migrating existing data.
+CROWBARR_MEDIA_MOUNT=/media
+# Optional second library, used only with compose.extra-media.yaml.
+# CROWBARR_EXTRA_MEDIA_DIR=/srv/movies
+# CROWBARR_EXTRA_MEDIA_MOUNT=/movies
+# Leave unset for the release branch's tested version, or latest on main.
+# CROWBARR_IMAGE_TAG=0.3.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,23 @@ on:
 
 permissions: {}
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 concurrency:
   group: crowbarr-release
   cancel-in-progress: false
 
 jobs:
+  tests:
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
+
   release-version:
     name: Read release version
+    needs: tests
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,23 +38,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - id: version
-        name: Create version tag when needed
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          python packaging/release_tools.py guard
           version="$(python -c 'from crowbarr.version import APPLICATION_VERSION; print(APPLICATION_VERSION)')"
-          series="${version%.*}"
           tag="v$version"
           publish=false
-
-          git fetch --tags --force
+          git fetch --tags
           if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
-            tagged_commit="$(git rev-list -n 1 "$tag")"
-            if [[ "$tagged_commit" == "$GITHUB_SHA" ]] && ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              publish=true
-            fi
+            test "$(git rev-list -n 1 "$tag")" = "$GITHUB_SHA"
+            publish=true
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -52,16 +57,15 @@ jobs:
             git push origin "$tag"
             publish=true
           fi
-
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "series=$series" >> "$GITHUB_OUTPUT"
+          echo "series=${version%.*}" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   image:
     if: needs.release-version.outputs.publish == 'true'
     needs: release-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -69,50 +73,65 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - variant: cpu
+          - variant: cpu-amd64
             dockerfile: Dockerfile
-            suffix: ""
-          - variant: cuda
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - variant: cuda-amd64
             dockerfile: Dockerfile.cuda
-            suffix: "-cuda"
+            platform: linux/amd64
+            runner: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      # The CUDA image is over 4 GB built and a hosted runner starts with roughly 14 GB
-      # free, which the build layers can exhaust.
       - name: Free runner disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
           sudo docker image prune -af
-          df -h /
-
       - uses: docker/setup-buildx-action@v3
-
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ needs.release-version.outputs.version }}${{ matrix.suffix }}
-            type=raw,value=${{ needs.release-version.outputs.series }}${{ matrix.suffix }}
-            type=raw,value=latest${{ matrix.suffix }}
-
-      - uses: docker/build-push-action@v6
+      - name: Build candidate locally
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: crowbarr:verify
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+      - name: Verify installed dependencies and spawned processing
+        run: |
+          docker run --rm --entrypoint python crowbarr:verify -m pip check
+          docker run --rm --entrypoint python -v "$PWD/packaging:/checks:ro" crowbarr:verify /checks/packaging_smoke.py
+          docker run -d --name verify-server crowbarr:verify
+          trap 'docker logs verify-server; docker rm -f verify-server' EXIT
+          for attempt in {1..30}; do
+            if docker exec verify-server python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8449/health', timeout=3)"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1
+      - name: Push verified candidate and record digest
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          candidate="$image:candidate-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$VARIANT"
+          docker tag crowbarr:verify "$candidate"
+          docker push "$candidate"
+          digest="$(docker buildx imagetools inspect "$candidate" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          mkdir -p digests
+          echo "$image@$digest" > "digests/$VARIANT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.variant }}
+          path: digests/*
+          if-no-files-found: error
 
   native-linux:
     name: Build Linux x86_64 package
@@ -123,41 +142,26 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-
+      - name: Free runner disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
-
-      - name: Build application
+      - name: Build application with CPU inference
         run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
           python -m pip install --upgrade pip
-          python -m pip install pyinstaller==6.16.0 '.[asr]'
-          pyinstaller \
-            --clean \
-            --noconfirm \
-            --onedir \
-            --name crowbarr \
-            --collect-all crowbarr \
-            --collect-all faster_whisper \
-            --collect-all ctranslate2 \
-            crowbarr/__main__.py
-
-      - name: Verify packaged server
-        run: |
-          data_dir="$(mktemp -d)"
-          CROWBARR_DATA="$data_dir" dist/crowbarr/crowbarr --host 127.0.0.1 --port 18449 >crowbarr.log 2>&1 &
-          server_pid=$!
-          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
-          for attempt in {1..20}; do
-            if curl -fsS http://127.0.0.1:18449/health | grep -F '"status":"ok"'; then
-              exit 0
-            fi
-            sleep 1
-          done
-          cat crowbarr.log
-          exit 1
-
+          python -m pip install torch==2.8.0 torchaudio==2.8.0 torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install pyinstaller==6.16.0 '.[inference]' torchcodec==0.7.0
+          python -m pip check
+          pyinstaller --clean --noconfirm --onedir --name crowbarr --paths packaging \
+            --collect-all crowbarr --collect-all faster_whisper --collect-all ctranslate2 \
+            --collect-all whisperx --collect-all transformers \
+            --hidden-import uvicorn.logging --hidden-import uvicorn.loops.auto \
+            --hidden-import uvicorn.protocols.http.auto --hidden-import uvicorn.protocols.websockets.auto \
+            --hidden-import uvicorn.lifespan.on packaging/package_entry.py
       - name: Package release assets
         run: |
           mkdir -p release-assets/staging
@@ -169,49 +173,118 @@ jobs:
           cd release-assets
           sha256sum crowbarr-linux-x86_64.tar.gz > crowbarr-linux-x86_64.tar.gz.sha256
           rm -rf staging
-
+      - name: Verify archive in clean runtime
+        run: |
+          python packaging/release_tools.py verify-assets release-assets
+          mkdir unpacked
+          tar -C unpacked -xzf release-assets/crowbarr-linux-x86_64.tar.gz
+          # No build environment or source tree is mounted into this runtime.
+          docker run --rm -v "$PWD/unpacked:/package:ro" ubuntu:22.04 bash -ec '
+            apt-get update >/dev/null
+            apt-get install -y ffmpeg curl libgomp1 >/dev/null
+            /package/crowbarr/crowbarr --packaging-smoke
+            CROWBARR_DATA=/tmp/config /package/crowbarr/crowbarr --host 127.0.0.1 --port 18449 >/tmp/server.log 2>&1 &
+            pid=$!
+            trap "kill $pid 2>/dev/null || true; cat /tmp/server.log" EXIT
+            for attempt in {1..30}; do
+              if curl -fsS http://127.0.0.1:18449/health; then exit 0; fi
+              sleep 1
+            done
+            exit 1'
       - uses: actions/upload-artifact@v4
         with:
           name: native-linux
           path: release-assets/*
           if-no-files-found: error
 
-  github-release:
-    name: Publish GitHub release
+  publish:
+    name: Publish verified assets
     if: needs.release-version.outputs.publish == 'true'
     needs: [release-version, image, native-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: native-linux
           path: release-assets
-
-      - name: Create release
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          merge-multiple: true
+          path: digests
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify all assets and reject stale runs before promotion
+        env:
+          VERSION: ${{ needs.release-version.outputs.version }}
+        run: |
+          python packaging/release_tools.py guard
+          python packaging/release_tools.py verify-assets release-assets
+          python packaging/release_tools.py verify-digests digests
+          python packaging/release_tools.py manifests "$VERSION" deploy-files
+      - name: Publish immutable version references
+        env:
+          VERSION: ${{ needs.release-version.outputs.version }}
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          python packaging/release_tools.py version-image "$image:$VERSION" digests/cpu-amd64
+          python packaging/release_tools.py version-image "$image:$VERSION-cuda" digests/cuda-amd64
+          docker buildx imagetools inspect "$image:$VERSION"
+          docker buildx imagetools inspect "$image:$VERSION-cuda"
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release-version.outputs.tag }}
           RELEASE_VERSION: ${{ needs.release-version.outputs.version }}
-          INSTALL_NOTES: |
-            ## Install on Linux x86_64
-
-            ```sh
-            curl -fsSL https://github.com/amanofvaly/crowbarr/releases/latest/download/install-crowbarr.sh | sudo bash
-            ```
-
-            Open `http://localhost:8449` after installation. Update later with `sudo crowbarr-update`.
         run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" release-assets/* \
-              --repo "$GITHUB_REPOSITORY" \
-              --clobber
-          else
-            gh release create "$RELEASE_TAG" release-assets/* \
-              --repo "$GITHUB_REPOSITORY" \
-              --verify-tag \
-              --generate-notes \
-              --notes "$INSTALL_NOTES" \
-              --title "Crowbarr $RELEASE_VERSION"
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" release-assets/* --repo "$GITHUB_REPOSITORY" \
+              --draft --verify-tag --generate-notes --title "Crowbarr $RELEASE_VERSION"
           fi
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir downloaded-assets
+          python packaging/release_tools.py verify-assets downloaded-assets
+          diff -r release-assets downloaded-assets
+          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+      - name: Promote channels only after all assets succeeded
+        env:
+          VERSION: ${{ needs.release-version.outputs.version }}
+          SERIES: ${{ needs.release-version.outputs.series }}
+        run: |
+          python packaging/release_tools.py guard
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          docker buildx imagetools create -t "$image:$SERIES" -t "$image:latest" "$image:$VERSION"
+          docker buildx imagetools create -t "$image:$SERIES-cuda" -t "$image:latest-cuda" "$image:$VERSION-cuda"
+      - name: Generate release-only GitOps branch
+        env:
+          VERSION: ${{ needs.release-version.outputs.version }}
+        run: |
+          python packaging/release_tools.py guard
+          if git ls-remote --exit-code origin refs/heads/release; then
+            git fetch origin release
+          else
+            test "$?" = 2
+          fi
+          parent="$(git rev-parse --verify refs/remotes/origin/release 2>/dev/null || true)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_INDEX_FILE="$RUNNER_TEMP/release-index"
+          rm -f "$GIT_INDEX_FILE"
+          git read-tree --empty
+          GIT_WORK_TREE="$PWD/deploy-files" git add --all
+          tree="$(git write-tree)"
+          if [[ -n "$parent" ]]; then
+            commit="$(git commit-tree "$tree" -p "$parent" -m "Release $VERSION")"
+          else
+            commit="$(git commit-tree "$tree" -m "Release $VERSION")"
+          fi
+          git push origin "$commit:refs/heads/release"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Tests
 on:
+  workflow_call:
   push:
     paths-ignore:
       - "**/*.md"
@@ -21,6 +22,6 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: pip install -e '.[test]'
-      - run: ruff check crowbarr tests integrations
+      - run: ruff check crowbarr tests integrations packaging
       - run: pytest
       - run: pip wheel --no-deps . -w dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,27 @@ release with split versioning requeues nothing.
 `APPLICATION_VERSION`. Identifies a published release. Changing it alone never
 re-audits anything.
 
+### 0.3.6
+
+- Published containers include the optional WhisperX refinement dependencies on CPU
+  and NVIDIA. Refinement remains off by default; the audit policy is unchanged.
+- Portainer can follow the public `release` branch for unattended, versioned
+  upgrades. Ordinary source pushes do not redeploy installations. Release channels
+  advance only after the test suite and packaged runtime checks pass.
+- Installs use persistent host storage with configurable UID/GID, ports and media
+  mounts. Missing directories fail before deployment. Migration instructions retain
+  the existing database, credentials, reports, models and cached transcription work.
+- Restarting with an open dashboard now drains within the service stop deadline.
+  Administrative interruptions refund their attempt and resume queued work; repeated
+  crashes stop at the configured retry limit. Invalid cached chunks are recomputed.
+- A replaced job request cannot be overwritten by an older worker. Legacy duplicate
+  job migration retains subtitle ownership and historical outcomes.
+- Native Linux upgrades retain installation paths and service identity, default new
+  installs to an unprivileged service account, and retain the prior binary for failed
+  start recovery. Daily updates are opt-in. Database rollback still requires a backup.
+- Native packages verify multiprocessing and processing imports in a clean runtime,
+  rather than testing only the dashboard health endpoint.
+
 ### 0.3.5
 
 - Linux x86_64 releases now include a runnable Crowbarr package and installer. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY pyproject.toml README.md LICENSE ./
 COPY crowbarr ./crowbarr
 RUN pip install --no-cache-dir torch==2.8.0 torchaudio==2.8.0 torchvision==0.23.0 \
     --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir '.[inference]'
+    && pip install --no-cache-dir '.[inference]' torchcodec==0.7.0 \
+    && pip check
 RUN mkdir -p /config && chown 1000:1000 /config
 USER 1000:1000
 EXPOSE 8449

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,14 +1,20 @@
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+FROM python:3.12-slim-bookworm
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 \
     CROWBARR_DATA=/config HF_HOME=/config/models/huggingface \
     TORCH_HOME=/config/models/torch NLTK_DATA=/config/models/nltk HOME=/config \
-    PATH=/opt/venv/bin:$PATH
+    NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    LD_LIBRARY_PATH=/usr/local/lib/python3.12/site-packages/nvidia/cublas/lib:/usr/local/lib/python3.12/site-packages/nvidia/cudnn/lib:/usr/local/lib/python3.12/site-packages/nvidia/cuda_runtime/lib
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends python3.11 python3.11-venv ffmpeg libgomp1 \
-    && rm -rf /var/lib/apt/lists/* && python3.11 -m venv /opt/venv
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml README.md LICENSE ./
 COPY crowbarr ./crowbarr
-RUN pip install --no-cache-dir '.[asr]'
+# PyTorch supplies the CUDA 12 libraries. Expose cuBLAS/cuDNN to CTranslate2 too.
+# cu126 is the oldest CUDA wheel supported by the pinned Torch/WhisperX pair.
+RUN pip install --no-cache-dir torch==2.8.0 torchaudio==2.8.0 torchvision==0.23.0 \
+    --index-url https://download.pytorch.org/whl/cu126 \
+    && pip install --no-cache-dir '.[inference]' torchcodec==0.7.0 \
+    && pip check
 RUN mkdir -p /config && chown 1000:1000 /config
 USER 1000:1000
 EXPOSE 8449

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All processed subtitles are published alongside your media as separate `.crowbar
 
 ## Installation
 
-Linux x86_64:
+Linux x86_64 with systemd:
 
 ```sh
 curl -fsSL https://github.com/amanofvaly/crowbarr/releases/latest/download/install-crowbarr.sh | sudo bash
@@ -39,6 +39,11 @@ Open `http://localhost:8449`. The installer adds Crowbarr as a system service an
 its database, settings, models, and cached transcripts in `/var/lib/crowbarr`.
 
 For Docker and NVIDIA installations, see [Install Crowbarr with Docker](docs/docker.md).
+For native permissions, scheduled updates and service recovery, see
+[Native Linux installation](docs/linux.md).
+For NAS app managers and unattended release updates, see
+[TrueNAS and Portainer](docs/nas.md). Existing users should read
+[Migration and backup](docs/migration.md) before changing installations.
 
 ### First run
 
@@ -54,6 +59,10 @@ For Docker and NVIDIA installations, see [Install Crowbarr with Docker](docs/doc
 ```sh
 sudo crowbarr-update
 ```
+
+This command updates manually. Container auto-updates use the managed
+[release-only Portainer setup](docs/nas.md#portainer). Ordinary source pushes do not
+update installations; a new application release must pass the release pipeline.
 
 The service stops while the program is replaced, then resumes with the existing data in
 `/var/lib/crowbarr`. An interrupted job returns to the queue. Other queued and completed

--- a/compose.cuda.yaml
+++ b/compose.cuda.yaml
@@ -3,7 +3,7 @@
 # Requires the NVIDIA Container Toolkit on the host.
 services:
   crowbarr:
-    image: ghcr.io/amanofvaly/crowbarr:latest-cuda
+    image: ghcr.io/amanofvaly/crowbarr:${CROWBARR_IMAGE_TAG:-latest}-cuda
     deploy:
       resources:
         reservations:

--- a/compose.extra-media.yaml
+++ b/compose.extra-media.yaml
@@ -1,0 +1,10 @@
+# Optional second library, for example movies stored separately from television.
+# Add with: docker compose -f compose.yaml -f compose.extra-media.yaml up -d
+services:
+  crowbarr:
+    volumes:
+      - type: bind
+        source: ${CROWBARR_EXTRA_MEDIA_DIR:?Set an absolute second media directory}
+        target: ${CROWBARR_EXTRA_MEDIA_MOUNT:-/media-extra}
+        bind:
+          create_host_path: false

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,18 +1,25 @@
 services:
   crowbarr:
-    image: ghcr.io/amanofvaly/crowbarr:latest
-    container_name: crowbarr
+    image: ghcr.io/amanofvaly/crowbarr:${CROWBARR_IMAGE_TAG:-latest}
     restart: unless-stopped
     init: true
     # The user and group that own your media files.
-    user: "1000:1000"
+    user: "${CROWBARR_UID:-1000}:${CROWBARR_GID:-1000}"
     ports:
-      - "8449:8449"
+      - "${CROWBARR_PORT:-8449}:8449"
     volumes:
       # Crowbarr's own storage: database, settings, models, cached transcripts.
-      - ./config:/config
+      - type: bind
+        source: ${CROWBARR_CONFIG_DIR:?Set an absolute persistent config directory}
+        target: /config
+        bind:
+          create_host_path: false
       # Your media library. Change the left side to your own path.
-      - /path/to/media:/media
+      - type: bind
+        source: ${CROWBARR_MEDIA_DIR:?Set an absolute media directory}
+        target: ${CROWBARR_MEDIA_MOUNT:-/media}
+        bind:
+          create_host_path: false
     stop_grace_period: 45s
     security_opt:
       - no-new-privileges:true

--- a/crowbarr/__main__.py
+++ b/crowbarr/__main__.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import argparse
+import multiprocessing
 import os
 
 
 def main():
+    multiprocessing.freeze_support()
     parser = argparse.ArgumentParser(description="Crowbarr automated subtitle service")
     parser.add_argument("--host", default=os.environ.get("CROWBARR_HOST", "0.0.0.0"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("CROWBARR_PORT", "8449")))
     args = parser.parse_args()
     import uvicorn
 
-    uvicorn.run("crowbarr.app:create_app", factory=True, host=args.host, port=args.port, workers=1)
+    uvicorn.run(
+        "crowbarr.app:create_app", factory=True, host=args.host, port=args.port,
+        workers=1, timeout_graceful_shutdown=5,
+    )
 
 
 if __name__ == "__main__":

--- a/crowbarr/app.py
+++ b/crowbarr/app.py
@@ -56,7 +56,7 @@ class BodyLimitMiddleware:
 
 
 def create_app(directory: Path | None = None, background: bool = True) -> FastAPI:
-    store = ConfigStore(directory or Path(os.environ.get("CROWBARR_DATA", "data")).resolve())
+    store = ConfigStore((directory or Path(os.environ.get("CROWBARR_DATA", "data"))).resolve())
     db = Database(store.directory / "crowbarr.db")
     service = Service(store, db)
 
@@ -64,9 +64,11 @@ def create_app(directory: Path | None = None, background: bool = True) -> FastAP
     async def lifespan(app):
         if background:
             service.start()
-        yield
-        if background:
-            service.close()
+        try:
+            yield
+        finally:
+            if background:
+                service.close()
 
     app = FastAPI(
         title="Crowbarr",
@@ -168,7 +170,7 @@ def create_app(directory: Path | None = None, background: bool = True) -> FastAP
 
         async def stream():
             previous, beat = None, 0.0
-            while True:
+            while not service.stop_event.is_set():
                 payload = await asyncio.to_thread(build_status)
                 encoded = _json.dumps(payload, default=str)
                 now = time.monotonic()

--- a/crowbarr/db.py
+++ b/crowbarr/db.py
@@ -7,11 +7,16 @@ from contextlib import contextmanager
 from pathlib import Path
 
 
+class StaleJob(RuntimeError):
+    """The worker's request has been replaced since it was claimed."""
+
+
 class Database:
     """A durable single-host queue. Transactions serialize claims across threads/processes."""
 
     def __init__(self, path: Path):
-        self.path = path
+        self.path = path.resolve()
+        self.worker_job = None
         path.parent.mkdir(parents=True, exist_ok=True)
         with self.connect() as db:
             db.execute("PRAGMA journal_mode=WAL")
@@ -50,6 +55,7 @@ class Database:
                     generation TEXT NOT NULL DEFAULT ''
                 );
             """)
+            db.execute("BEGIN IMMEDIATE")
             columns = {row[1] for row in db.execute("PRAGMA table_info(jobs)")}
             for name, definition in {
                 "origin": "TEXT NOT NULL DEFAULT 'backlog'",
@@ -60,6 +66,7 @@ class Database:
                 "progress_total": "REAL",
                 "cached": "INTEGER",
                 "started": "REAL",
+                "generation": "INTEGER NOT NULL DEFAULT 0",
             }.items():
                 if name not in columns:
                     db.execute(f"ALTER TABLE jobs ADD COLUMN {name} {definition}")
@@ -81,9 +88,30 @@ class Database:
             # (file, inputs) pair. A row per revision turns a state question into an
             # ever-growing log: files get counted twice, finished verdicts are buried
             # under re-queued duplicates, and ids climb without bound.
-            db.execute(
-                "DELETE FROM jobs WHERE id NOT IN (SELECT MAX(id) FROM jobs GROUP BY media)"
-            )
+            obsolete = db.execute(
+                "SELECT * FROM jobs WHERE id NOT IN (SELECT MAX(id) FROM jobs GROUP BY media)"
+            ).fetchall()
+            for row in obsolete:
+                try:
+                    report = json.loads(row["report"] or "{}")
+                    digest = report.get("output_sha256") if isinstance(report, dict) else None
+                except (ValueError, TypeError):
+                    digest = None
+                if row["output"] and isinstance(digest, str) and digest:
+                    db.execute(
+                        "INSERT OR IGNORE INTO artifacts VALUES (?,?,?,?,?)",
+                        (row["media"], row["output"], digest, row["id"], row["updated"]),
+                    )
+                if row["state"] in {"completed", "unchanged", "review", "failed", "skipped"}:
+                    db.execute(
+                        "INSERT INTO history(job_id,media,state,error,output,finished) "
+                        "SELECT ?,?,?,?,?,? WHERE NOT EXISTS (SELECT 1 FROM history WHERE job_id=?)",
+                        (row["id"], row["media"], row["state"], row["error"], row["output"],
+                         row["updated"], row["id"]),
+                    )
+                # A removed revision cannot supply a current detail report.
+                db.execute("UPDATE history SET job_id=NULL WHERE job_id=?", (row["id"],))
+                db.execute("DELETE FROM jobs WHERE id=?", (row["id"],))
             db.execute("CREATE UNIQUE INDEX IF NOT EXISTS jobs_media ON jobs(media)")
             if "generation" not in {row[1] for row in db.execute("PRAGMA table_info(provider_sync)")}:
                 db.execute("ALTER TABLE provider_sync ADD COLUMN generation TEXT NOT NULL DEFAULT ''")
@@ -94,9 +122,18 @@ class Database:
         db.row_factory = sqlite3.Row
         try:
             with db:
+                if self.worker_job is not None:
+                    db.execute("BEGIN IMMEDIATE")
+                    if not db.execute(
+                        "SELECT 1 FROM jobs WHERE id=? AND generation=?", self.worker_job
+                    ).fetchone():
+                        raise StaleJob("Job request was replaced")
                 yield db
         finally:
             db.close()
+
+    def bind_worker(self, job: dict) -> None:
+        self.worker_job = (job["id"], job["generation"])
 
     def notice(self, name: str, message: str) -> None:
         with self.connect() as db:
@@ -184,7 +221,8 @@ class Database:
             db.execute(
                 "UPDATE jobs SET signature=?,source=?,state=?,ready=?,created=?,updated=?,origin=?,priority=?,"
                 "stage='',attempts=0,error=NULL,cancel_requested=0,directive='',"
-                "progress_current=NULL,progress_total=NULL,started=NULL WHERE id=?",
+                "progress_current=NULL,progress_total=NULL,started=NULL,cached=NULL,"
+                "generation=generation+1 WHERE id=?",
                 (signature, source, state, ready, now, now, origin, priority, row["id"]),
             )
             return row["id"]
@@ -287,7 +325,8 @@ class Database:
                 return None
             db.execute(
                 "UPDATE jobs SET state='processing',stage='Preparing audio',attempts=attempts+1,"
-                "updated=?,started=?,progress_current=NULL,progress_total=NULL,error=NULL WHERE id=?",
+                "updated=?,started=?,progress_current=NULL,progress_total=NULL,cached=NULL,"
+                "generation=generation+1,error=NULL WHERE id=?",
                 (now, now, row["id"]),
             )
             return dict(db.execute("SELECT * FROM jobs WHERE id=?", (row["id"],)).fetchone())
@@ -310,7 +349,7 @@ class Database:
                 for row in db.execute("SELECT report FROM jobs WHERE media=? AND output=?", (media, path))
             )
 
-    def update(self, job_id: int, **values) -> None:
+    def update(self, job_id: int, *, expected_generation: int | None = None, **values) -> bool:
         allowed = {
             "state",
             "stage",
@@ -334,10 +373,13 @@ class Database:
             values.update(progress_current=None, progress_total=None)
         values["updated"] = time.time()
         with self.connect() as db:
-            db.execute(
-                "UPDATE jobs SET " + ",".join(f"{key}=?" for key in values) + " WHERE id=?",
-                (*values.values(), job_id),
+            result = db.execute(
+                "UPDATE jobs SET " + ",".join(f"{key}=?" for key in values) + " WHERE id=?"
+                + (" AND generation=?" if expected_generation is not None else ""),
+                (*values.values(), job_id, *((expected_generation,) if expected_generation is not None else ())),
             )
+            if not result.rowcount:
+                return False
             if values.get("state") in ("completed", "unchanged", "review", "failed"):
                 row = db.execute("SELECT media,state,error,output FROM jobs WHERE id=?", (job_id,)).fetchone()
                 if row:
@@ -350,18 +392,29 @@ class Database:
                         "DELETE FROM history WHERE id NOT IN "
                         "(SELECT id FROM history ORDER BY finished DESC LIMIT 5000)"
                     )
+            return True
 
-    def recover(self) -> None:
+    def recover(self, max_attempts: int = 3) -> None:
         # Called only after the service acquires the exclusive process lock.
         with self.connect() as db:
+            db.execute(
+                "INSERT INTO history(job_id,media,state,error,output,finished) "
+                "SELECT id,media,'failed','Service restarted; attempt limit reached',output,? "
+                "FROM jobs WHERE state='processing' AND attempts>=? AND cancel_requested=0",
+                (time.time(), max_attempts),
+            )
             db.execute(
                 # A graceful stop already moved its job out of 'processing' and refunded the
                 # attempt. Anything still 'processing' died with the service, so it must keep
                 # the attempt: a job that reliably kills the container has to fail out instead
                 # of restart-looping forever.
-                "UPDATE jobs SET state='retry',stage='',ready=?,updated=?,"
-                "error='Service restarted; job will resume' WHERE state='processing'",
-                (time.time(), time.time()),
+                "UPDATE jobs SET state=CASE WHEN cancel_requested=1 THEN 'cancelled' "
+                "WHEN attempts>=? THEN 'failed' ELSE 'retry' END,"
+                "stage='',ready=?,updated=?,progress_current=NULL,progress_total=NULL,started=NULL,cached=NULL,"
+                "generation=generation+1,error=CASE WHEN cancel_requested=1 THEN 'Cancelled by user' "
+                "WHEN attempts>=? THEN 'Service restarted; attempt limit reached' "
+                "ELSE 'Service restarted; job will resume' END WHERE state='processing'",
+                (max_attempts, time.time(), time.time(), max_attempts),
             )
 
     def get(self, job_id: int) -> dict | None:
@@ -410,7 +463,8 @@ class Database:
             return bool(
                 db.execute(
                     "UPDATE jobs SET directive=?,state='queued',stage='',origin='manual',priority=100,"
-                    "cancel_requested=0,ready=?,updated=?,attempts=0,error=NULL WHERE id=?",
+                    "cancel_requested=0,ready=?,updated=?,attempts=0,error=NULL,"
+                    "generation=generation+1,progress_current=NULL,progress_total=NULL,started=NULL,cached=NULL WHERE id=?",
                     (directive, time.time(), time.time(), job_id),
                 ).rowcount
             )

--- a/crowbarr/inference.py
+++ b/crowbarr/inference.py
@@ -213,12 +213,29 @@ def transcribe_bounded(audio: Path, settings: Settings, cache: Path, checkpoint:
             core_start, core_end = index * 300, min(duration, (index + 1) * 300)
             start, end = max(0, core_start - 2), min(duration, core_end + 2)
             saved = checkpoint / f"{index}.json"
+            chunk = None
             if saved.exists():
-                payload = json.loads(saved.read_text())
-                chunk = [Word(**word) for word in payload["words"]]
-                warnings = payload["issues"]
-                transcribe.runtime = payload.get("runtime", {"backend": "cached"})
-            else:
+                try:
+                    payload = json.loads(saved.read_text())
+                    restored = [Word(**word) for word in payload["words"]]
+                    warnings = payload["issues"]
+                    runtime = payload.get("runtime", {"backend": "cached"})
+                    if not isinstance(warnings, list) or not all(isinstance(w, str) for w in warnings):
+                        raise ValueError("Invalid checkpoint warnings")
+                    if not isinstance(runtime, dict) or any(
+                        not isinstance(w.text, str)
+                        or not all(isinstance(v, (int, float)) and math.isfinite(v)
+                                   for v in (w.start, w.end, w.probability))
+                        or not core_start <= w.start < core_end or w.end <= w.start
+                        or not 0 <= w.probability <= 1
+                        for w in restored
+                    ):
+                        raise ValueError("Invalid checkpoint words")
+                    chunk = restored
+                    transcribe.runtime = runtime
+                except (ValueError, TypeError, KeyError, UnicodeError):
+                    pass  # Recompute only this chunk; keep the other durable checkpoints.
+            if chunk is None:
                 clip = Path(work) / "chunk.wav"
                 source.setpos(int(start * rate))
                 with wave.open(str(clip), "wb") as target:

--- a/crowbarr/processor.py
+++ b/crowbarr/processor.py
@@ -682,10 +682,8 @@ def process(
                 try:
                     aligned, alignment_issues = aligner(audio, alignment_passages, settings, cache)
                 except ImportError as error:
-                    # The CUDA image ships recognition without WhisperX, which would pull
-                    # a second CUDA torch stack for an off-by-default refinement. A build
-                    # that cannot honour the setting must fall back to Whisper's own word
-                    # timestamps and say so, not fail the job on an import.
+                    # Minimal source installs can omit optional refinement dependencies.
+                    # Keep usable Whisper timings and report the missing capability.
                     warnings.append(
                         f"WhisperX refinement is not installed in this image ({error}); "
                         "used Whisper word timestamps instead"

--- a/crowbarr/service.py
+++ b/crowbarr/service.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 
 from .config import ConfigStore, Settings, atomic_write
-from .db import Database
+from .db import Database, StaleJob
 from .integrations import deliver_plex, plex_activity, refresh_plex
 from .library import scan
 from .media import ReviewRequired
@@ -36,6 +36,7 @@ def run_job(directory: str, job: dict, settings_data: dict) -> None:
         except (OSError, subprocess.SubprocessError):
             pass
     db = Database(Path(directory) / "crowbarr.db")
+    db.bind_worker(job)
     try:
         result = process(job, settings, Path(directory), db)
         if settings.plex.url and result.get("output") and result["state"] == "completed":
@@ -51,9 +52,15 @@ def run_job(directory: str, job: dict, settings_data: dict) -> None:
             db.notice("plex-refresh", "Subtitles updated; Plex refresh pending.")
         db.update(job["id"], **result)
         if result.get("report"):
-            atomic_write(Path(directory) / "reports" / f"{job['id']}.json", result["report"])
+            with db.connect():
+                atomic_write(Path(directory) / "reports" / f"{job['id']}.json", result["report"])
+    except StaleJob:
+        return
     except ReviewRequired as error:
-        db.update(job["id"], state="review", stage="Needs attention", error=str(error))
+        try:
+            db.update(job["id"], state="review", stage="Needs attention", error=str(error))
+        except StaleJob:
+            pass
     except Exception as error:
         # Avoid exception payloads that may include credentials or external request URLs.
         name = type(error).__name__
@@ -61,15 +68,18 @@ def run_job(directory: str, job: dict, settings_data: dict) -> None:
         # on a failure at all. It goes to the log, which is not rendered in the UI.
         log.error("Job %s failed (%s)", job["id"], name, exc_info=True)
         retry = job["attempts"] < settings.max_attempts
-        db.update(
-            job["id"],
-            state="retry" if retry else "failed",
-            stage="",
-            error=f"{name}: processing failed. Check model availability, resources, and media access.",
-            ready=time.time() + min(3600, 60 * 2 ** job["attempts"]),
-            origin="retry",
-            priority=40,
-        )
+        try:
+            db.update(
+                job["id"],
+                state="retry" if retry else "failed",
+                stage="",
+                error=f"{name}: processing failed. Check model availability, resources, and media access.",
+                ready=time.time() + min(3600, 60 * 2 ** job["attempts"]),
+                origin="retry",
+                priority=40,
+            )
+        except StaleJob:
+            pass
 
 
 class Service:
@@ -87,6 +97,7 @@ class Service:
         self.last_background_end = 0
         self.last_resource_check = 0
         self.plex_busy = False
+        self.child_pid = None
 
     def start(self):
         self.lock_file = (self.store.directory / "service.lock").open("a")
@@ -95,7 +106,7 @@ class Service:
         except BlockingIOError:
             self.lock_file.close()
             raise RuntimeError("Another Crowbarr service is already using this data directory") from None
-        self.db.recover()
+        self.db.recover(self.store.get().max_attempts)
         from .audit import AUDIT_VERSION
 
         reopened = self.db.adopt_policy(AUDIT_VERSION)
@@ -111,12 +122,33 @@ class Service:
             thread.start()
             self.threads.append(thread)
 
-    def close(self):
+    def close(self, timeout: float = 20):
         self.stop_event.set()
         self.scan_event.set()
+        deadline = time.monotonic() + timeout
         for thread in self.threads:
-            thread.join(timeout=25)
-        if self.lock_file:
+            thread.join(timeout=max(0, deadline - time.monotonic()))
+        if any(thread.is_alive() for thread in self.threads):
+            child_pid = self.child_pid
+            if child_pid is not None:
+                try:
+                    os.killpg(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    try:
+                        os.kill(child_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+            log.warning("Shutdown deadline reached; retaining data lock until background threads exit")
+            # Slow filesystem/network operations cannot be cancelled in a Python thread.
+            # Do not let a second service use the data while those operations still run.
+            def release_when_stopped():
+                for thread in self.threads:
+                    thread.join()
+                if self.lock_file:
+                    self.lock_file.close()
+
+            threading.Thread(target=release_when_stopped, daemon=True).start()
+        elif self.lock_file:
             self.lock_file.close()
 
     def scanner(self):
@@ -124,6 +156,8 @@ class Service:
             self.scan_event.clear()
             try:
                 self.scan_count = scan(self.store.get(), self.db)
+                if self.stop_event.is_set():
+                    break
                 self.db.prune()
                 self.last_scan = time.time()
                 settings = self.store.get()
@@ -136,6 +170,8 @@ class Service:
                             )
                         ]
                     for job in pending:
+                        if self.stop_event.is_set():
+                            break
                         report = json.loads(job["report"])
                         attempts = report["plex_delivery"].get("attempts", 0)
                         if attempts >= 5:
@@ -206,14 +242,22 @@ class Service:
             )
             if not job:
                 continue
+            if self.stop_event.is_set():
+                self.db.update(
+                    job["id"], expected_generation=job["generation"], state="retry", stage="",
+                    attempts=max(0, job["attempts"] - 1), ready=time.time(),
+                )
+                break
             child = context.Process(
                 target=run_job, args=(str(self.store.directory), job, settings.model_dump())
             )
             try:
                 child.start()
+                self.child_pid = child.pid
             except Exception:
                 self.db.update(
-                    job["id"], state="failed", stage="", error="Could not start the inference process"
+                    job["id"], expected_generation=job["generation"],
+                    state="failed", stage="", error="Could not start the inference process"
                 )
                 continue
             started = time.monotonic()
@@ -223,10 +267,10 @@ class Service:
             while child.is_alive():
                 child.join(timeout=1)
                 current = self.store.get()
-                if time.monotonic() - self.last_resource_check > 10:
-                    self.resources = resource_snapshot()
-                    self.last_resource_check = time.monotonic()
-                if self.db.get(job["id"]).get("cancel_requested"):
+                latest = self.db.get(job["id"])
+                if not latest or latest["generation"] != job["generation"]:
+                    interrupted = "Job request replaced"
+                elif latest.get("cancel_requested"):
                     interrupted = "Cancelled by user"
                 elif self.stop_event.is_set():
                     interrupted = "Service stopping"
@@ -239,33 +283,43 @@ class Service:
                     interrupted = "Media is no longer eligible in the arr library"
                 elif time.monotonic() - started > settings.job_timeout_minutes * 60:
                     interrupted = "Job exceeded its configured time limit"
+                if not interrupted and time.monotonic() - self.last_resource_check > 10:
+                    self.resources = resource_snapshot()
+                    self.last_resource_check = time.monotonic()
                 if interrupted:
                     try:
                         os.killpg(child.pid, signal.SIGTERM)
                     except ProcessLookupError:
                         child.terminate()
                     child.join(timeout=10)
-                    if child.is_alive():
-                        try:
-                            os.killpg(child.pid, signal.SIGKILL)
-                        except ProcessLookupError:
+                    # The leader may exit before an FFmpeg descendant does.
+                    try:
+                        os.killpg(child.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        if child.is_alive():
                             child.kill()
-                        child.join(timeout=5)
+                    child.join(timeout=5)
                     break
             latest = self.db.get(job["id"])
-            if latest and latest["state"] == "processing":
-                retry = job["attempts"] < settings.max_attempts
+            if latest and latest["generation"] == job["generation"] and latest["state"] == "processing":
+                administrative = interrupted in {"Service stopping", "Processing settings changed"}
+                attempts = max(0, job["attempts"] - 1) if administrative else job["attempts"]
+                retry = attempts < settings.max_attempts
                 self.db.update(
                     job["id"],
+                    expected_generation=job["generation"],
                     state="superseded"
                     if interrupted == "Media is no longer eligible in the arr library"
+                    else "cancelled" if interrupted == "Cancelled by user"
                     else ("retry" if retry else "failed"),
                     stage="",
                     error=interrupted or "Inference process exited unexpectedly; check available memory",
                     ready=time.time() + (0 if interrupted in {"Service stopping", "Processing settings changed"} else 120),
                     origin=job.get("origin", "backlog") if interrupted in {"Service stopping", "Processing settings changed"} else "retry",
                     priority=job.get("priority", 0) if interrupted in {"Service stopping", "Processing settings changed"} else 40,
-                    attempts=max(0, job["attempts"]-1) if interrupted in {"Service stopping", "Processing settings changed"} else job["attempts"],
+                    attempts=attempts,
+                    started=None,
+                    cached=None,
                 )
             elif latest and latest["state"] == "completed":
                 self.scan_event.set()
@@ -276,7 +330,6 @@ class Service:
             if did_work and job.get("origin", "backlog") not in {"manual", "import"}:
                 self.last_background_end = time.time()
                 self.db.record_usage(wall_started, time.monotonic() - started)
-            if interrupted == "Cancelled by user" and latest and latest["state"] == "processing":
-                self.db.update(job["id"], state="cancelled", stage="", error=interrupted)
+            self.child_pid = None
             child.close()
             shutil.rmtree(self.store.directory / "work", ignore_errors=True)

--- a/crowbarr/version.py
+++ b/crowbarr/version.py
@@ -9,5 +9,5 @@ What each value means for an installation is recorded in ``CHANGELOG.md``, not h
 Changing either without an entry there fails ``tests/test_release.py``.
 """
 
-APPLICATION_VERSION = "0.3.5"
+APPLICATION_VERSION = "0.3.6"
 AUDIT_POLICY_VERSION = "0.3.4"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,25 +1,56 @@
 # Install Crowbarr with Docker
 
+Published images currently support Linux x86_64 (`linux/amd64`). ARM64 images are
+not yet published. Use Docker Engine with its Compose plugin or a Docker-based NAS
+app manager. Native Windows/macOS packages are not provided.
+
 ## Docker Compose
 
-Save this as `compose.yaml`, change the two marked lines, then run
-`docker compose up -d`.
+Save this as `compose.yaml`. Set the host storage paths and the numeric user/group
+that can write to your media, then run `docker compose up -d`. No `.env` is required.
 
 ```yaml
 services:
   crowbarr:
     image: ghcr.io/amanofvaly/crowbarr:latest
-    container_name: crowbarr
     restart: unless-stopped
     init: true
     user: "1000:1000"            # the user and group that own your media
     ports:
       - "8449:8449"
     volumes:
-      - ./config:/config
-      - /path/to/media:/media    # your library
+      - type: bind
+        source: /srv/crowbarr/config   # existing private app directory
+        target: /config
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /path/to/media        # existing library directory
+        target: /media
+        bind:
+          create_host_path: false
     stop_grace_period: 45s
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 ```
+
+Create the configuration directory first. For UID/GID 1000:
+
+```sh
+sudo install -d -m 0700 -o 1000 -g 1000 /srv/crowbarr/config
+```
+
+Use the paths and IDs chosen above. On a NAS, create app storage and grant access
+through the dataset permissions screen. Do not recursively change media ownership
+or grant access to everyone. Missing directories are rejected instead of silently
+creating empty, root-owned storage.
+
+For managed installs and unattended updates, see [TrueNAS and Portainer](nas.md).
+Before replacing an existing installation, read [Migration and backup](migration.md).
+
+## NVIDIA
 
 For an NVIDIA GPU, install the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html),
@@ -36,6 +67,14 @@ use `ghcr.io/amanofvaly/crowbarr:latest-cuda`, and add the device reservation:
 ```
 
 Open `http://localhost:8449` after the container starts.
+Use the server's IP address when opening it from another computer. Create your
+dashboard account and configure Sonarr/Radarr in Settings. Map their media paths
+to paths visible inside Crowbarr, such as `/media`. Service URLs must be reachable
+from the container: `localhost` refers to Crowbarr itself.
+
+Select CUDA in Settings when using the NVIDIA image. The image does not override
+your saved processing settings. On TrueNAS, configure its GPU support rather than
+installing driver packages on the host.
 
 ## Docker Run
 
@@ -45,16 +84,21 @@ docker run -d \
   --restart unless-stopped \
   --user 1000:1000 \
   -p 8449:8449 \
-  -v ./config:/config \
-  -v /path/to/media:/media \
+  --init \
+  --stop-timeout 45 \
+  --mount type=bind,src=/srv/crowbarr/config,dst=/config \
+  --mount type=bind,src=/path/to/media,dst=/media \
   ghcr.io/amanofvaly/crowbarr:latest
 ```
 
 Crowbarr writes subtitles beside the video files. Run the container with the uid and
 gid that own those files. Keep `/config` persistent because it contains the database,
-settings, downloaded models, and cached transcripts.
+settings, login credentials, API key, reports, downloaded models, and cached
+transcripts. Published subtitles remain alongside the media.
 
 Allow roughly 115 MB of free disk space per hour of audio during extraction.
+Model and transcript caches require additional space. The first inference downloads
+models and requires outbound network access.
 
 ## Update
 
@@ -63,9 +107,34 @@ docker compose pull
 docker compose up -d
 ```
 
-An interrupted job returns to the queue when the replacement container starts. Other
-queued and completed work remains in `/config`.
+These commands update manually. `latest` and `restart: unless-stopped` do not schedule
+updates. For unattended release updates, use [Portainer GitOps](nas.md#portainer).
 
-To roll back, pin an earlier image tag and run `docker compose up -d` again. Rolling
-back the application does not reverse an audit policy change already stored in the
-database.
+An administrative interruption returns the job to the queue. Valid recognition
+checkpoints can resume; the current unfinished chunk may repeat. Other queued and
+completed work remains in `/config`. An application version change alone does not
+re-audit settled jobs.
+
+Read [rollback requirements](migration.md#rollback) before selecting an older image.
+Changing the image does not reverse database migrations, audit-policy adoption, or
+subtitle publications.
+
+## Troubleshooting
+
+```sh
+docker compose ps
+docker compose logs --tail=100 crowbarr
+docker compose exec crowbarr id
+docker compose exec crowbarr sh -c 'test -w /config && echo "Config is writable"'
+```
+
+Test your media mount in the same way, replacing `/config` with its container path.
+For permission failures, check UID/GID, parent directory traversal and NAS ACLs.
+Crowbarr does not change host ownership automatically. Verify a real job: HTTP health
+alone does not prove that downloads, GPU inference, or subtitle publication work.
+
+If a migrated installation asks you to create an account, stop and check the host
+directory mounted at `/config`. Do not delete or reset the existing data.
+
+Keep the dashboard on your trusted network or use authenticated TLS access through
+a reverse proxy. Remove keys, cookies and private media names from shared logs.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,64 @@
+# Native Linux installation
+
+Use the native package on Linux x86_64 with systemd and glibc 2.35 or newer
+(Ubuntu 22.04+, Debian 12+, or a compatible distribution). ARM and Alpine/musl
+native packages are not currently published. On TrueNAS, use [Apps or Portainer](nas.md)
+instead of installing software into the NAS operating system.
+
+```sh
+curl -fsSL https://github.com/amanofvaly/crowbarr/releases/latest/download/install-crowbarr.sh | sudo bash
+```
+
+The installer creates an unprivileged `crowbarr` service account, installs the
+application under `/opt/crowbarr`, and keeps data under `/var/lib/crowbarr`.
+Grant that account access to traverse and write to your media directories using
+their existing group or ACL. Do not recursively change media ownership.
+
+Open `http://SERVER-IP:8449`, create your dashboard account and configure services
+in Settings. Use CPU processing with the native package. For supported NVIDIA
+installation, use the [CUDA container](docker.md#nvidia).
+
+## Updates
+
+```sh
+sudo crowbarr-update
+```
+
+Installation settings persist in `/etc/crowbarr/installer.env`. Upgrades retain
+the service account and data paths, including supported older installer settings.
+Application binaries and data must live in separate directories.
+
+To enable unattended daily release updates:
+
+```sh
+sudo env CROWBARR_AUTO_UPDATE=true crowbarr-update
+systemctl list-timers crowbarr-update.timer
+```
+
+To disable them:
+
+```sh
+sudo env CROWBARR_AUTO_UPDATE=false crowbarr-update
+```
+
+The timer follows published GitHub releases, not source pushes. It runs daily with
+up to an hour of randomized delay. Keep recoverable backups and read release notes.
+
+For existing media permissions, an installer invocation may explicitly select an
+existing account/group using `CROWBARR_USER` and `CROWBARR_GROUP`. Other supported
+options are `CROWBARR_DATA_DIR`, `CROWBARR_INSTALL_DIR`, and `CROWBARR_VERSION`.
+Run these through `sudo env NAME=value ...` so sudo passes them to the installer.
+These options are not required for a normal install.
+
+## Status and recovery
+
+```sh
+systemctl status crowbarr
+journalctl -u crowbarr -n 100 --no-pager
+journalctl -u crowbarr-update -n 100 --no-pager
+```
+
+If the replacement does not start, the installer restores the prior binary and
+service settings. That does not reverse database migrations or subtitle writes.
+Follow [Migration and backup](migration.md#rollback) for full rollback. Old binaries
+remain in `/opt/crowbarr.versions`; retain the version matching your backup.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,80 @@
+# Migration and backup
+
+Keep the existing data and install the published application. Crowbarr stores its
+settings, login credentials, API key, job state, reports, model caches and transcript
+checkpoints in its data directory (`/config` in Docker, `/var/lib/crowbarr` by default
+on native Linux). Subtitle sidecars remain beside the media.
+
+## Before moving
+
+1. Record application and audit-policy versions, image tag/digest, UID/GID, host
+   mounts, container paths, port and GPU selection. Keep the working image available.
+2. Record queue totals and representative completed/review jobs in the dashboard.
+3. Identify the actual data directory. For Docker, inspect container mounts with
+   `docker inspect CONTAINER`; do not infer paths from an example.
+4. Preserve the numeric UID/GID and container media paths. Jobs, reports and caches
+   contain absolute paths. Changing `/tv` to `/media/tv` is not a transparent move.
+   Use the supported mount settings to retain `/tv` and any other existing paths.
+5. Disable the old updater, pause the queue in the dashboard and let the active job
+   finish if convenient. Pause prevents new claims; stopping can interrupt a chunk.
+
+## Back up
+
+Stop Crowbarr through its manager and confirm it has exited. Back up the entire data
+directory while stopped, preserving ownership, permissions and links. On TrueNAS,
+take a snapshot of the dataset containing the data after stopping the service.
+A snapshot on the same device does not protect against device failure; maintain a
+recoverable backup too.
+
+For a regular Linux directory, an example is:
+
+```sh
+sudo tar --acls --xattrs --numeric-owner -C /srv/crowbarr \
+  -cpf /backup/crowbarr-before-upgrade.tar config
+```
+
+Replace both paths. Protect backups because they contain credentials. Never copy
+only `crowbarr.db` while running: committed changes may be in `crowbarr.db-wal`.
+Keep settings, dashboard credentials, the API token, transcripts, reports,
+candidates, models and the remaining app data together.
+
+## Switch managers
+
+Follow the public [Docker](docker.md) or [Portainer](nas.md#portainer) instructions.
+Point configuration storage at the existing data directory, or a complete
+stopped-service copy. Preserve media paths, UID/GID, port and GPU settings.
+
+Keep the old container stopped. Never run two services against the same database,
+or independent database copies writing to the same library. Retain the stopped old
+container until the replacement has been verified.
+
+## Verify
+
+Check the new published version and container health. Sign in with the existing
+account. Verify settings, integrations, API key continuity, queue counts, completed
+and review history, and reports. Check media access as the configured user. Resume
+the queue if paused and observe a real job reach its normal completion/review state.
+
+An application-only update leaves settled results intact. An audit-policy change
+can reopen review/failed jobs as described in the [changelog](../CHANGELOG.md).
+Interrupted jobs return to the queue subject to retry limits. Valid recognition
+chunks can resume; the unfinished chunk may repeat. An in-memory progress percentage
+is not guaranteed to survive exactly.
+
+If an existing installation asks you to create an account, stop and check `/config`.
+If jobs show missing media, check container mount paths before resetting or rescanning.
+Fix installation defects in the shared release or instructions, rather than patching
+a running container.
+
+## Rollback
+
+Stop the replacement and disable its updater. Save its current data before restoring
+an older backup, since restoring discards changes made after that backup. Restore
+the complete pre-upgrade data with ownership and permissions, then start the matching
+old release. Verify health and the dashboard again.
+
+An older image alone does not reverse schema migrations, policy adoption or new
+subtitle publications. Verify old-version database compatibility or restore its
+matching data backup. App-data rollback does not restore media-side subtitle files;
+use media backups/snapshots when those also need reverting. Do not delete existing
+subtitles to make a rollback appear healthy.

--- a/docs/nas.md
+++ b/docs/nas.md
@@ -1,0 +1,71 @@
+# TrueNAS and Portainer
+
+Install the published image and configure connections in the dashboard, as with
+Sonarr, Radarr or Bazarr. The host needs storage paths, a port, numeric user/group
+IDs and optional GPU access. No source edits, local builds or helper scripts are
+required. Use the same public release on every server.
+
+## TrueNAS Apps
+
+TrueNAS SCALE 24.10 and newer use Docker-based Apps. Use **Apps > Discover Apps >
+Custom App** to install `ghcr.io/amanofvaly/crowbarr:latest` (or `latest-cuda` for
+NVIDIA). Set container port 8449, the app UID/GID, a persistent host directory mounted
+at `/config`, and your library mounted at `/media`. Grant that user write access to
+the app dataset and media. Keep configuration storage private.
+
+Alternatively, use **Install via YAML** with the [Docker Compose example](docker.md).
+Crowbarr appears in the TrueNAS Apps list. A TrueNAS Custom App is its standard way
+to install an app outside the catalog; it does not require a customized application.
+Do not run the native Linux installer or install driver packages on the NAS host.
+See [TrueNAS custom app instructions](https://apps.truenas.com/managing-apps/installing-custom-apps/).
+
+TrueNAS offers image update checks, but notification is different from automatic
+installation. For unattended Git-based release updates, use Portainer below.
+
+## Portainer
+
+Use a Docker Standalone environment. Portainer itself can be a TrueNAS App.
+Crowbarr will appear as a Portainer stack, not as a separate TrueNAS-managed App.
+Use one manager for Crowbarr's lifecycle.
+
+1. Open **Stacks > Add stack**, name it `crowbarr`, and select **Git repository**.
+2. Enter `https://github.com/amanofvaly/crowbarr`, reference `refs/heads/release`,
+   and Compose path `compose.yaml`. The public repository needs no GitHub credentials.
+3. For NVIDIA, add `compose.cuda.yaml` under additional paths.
+4. In the stack's environment fields, enter `CROWBARR_CONFIG_DIR` and
+   `CROWBARR_MEDIA_DIR` as existing absolute host directories, plus `CROWBARR_UID`
+   and `CROWBARR_GID` as the user/group that can write to them. Set `CROWBARR_PORT`
+   only if you want a port other than 8449. No `.env` file is required.
+5. Enable **GitOps updates**, choose **Polling** and an interval such as five minutes.
+   Enable **Re-pull image** and leave **Force redeployment** disabled.
+   Leave `CROWBARR_IMAGE_TAG` unset so the release branch selects the version.
+6. Deploy. Check container health, open `http://SERVER-IP:8449`, and configure
+   services in the dashboard. Select CUDA in Settings if using the NVIDIA image.
+
+For two separate libraries, add `compose.extra-media.yaml` and enter
+`CROWBARR_EXTRA_MEDIA_DIR`. The default container mounts are `/media` and
+`/media-extra`. During migration, preserve existing paths with `CROWBARR_MEDIA_MOUNT`
+and `CROWBARR_EXTRA_MEDIA_MOUNT`, for example `/tv` and `/movies`. Read
+[Migration and backup](migration.md) first.
+
+App data lives outside Portainer's Git checkout. Do not use relative-path volumes
+for persistent configuration. If your Portainer edition does not expose GitOps
+polling, use manual pull/redeploy or an edition with that feature. Creating a stack
+from Git does not by itself enable polling. See
+[Portainer GitOps documentation](https://docs.portainer.io/user/docker/stacks/add#gitops-updates).
+
+## What triggers an update?
+
+An ordinary push does not publish a release. Changing `APPLICATION_VERSION` on
+`main` starts the release pipeline. After tests and packaged-build checks succeed,
+the pipeline publishes versioned artifacts and advances the `release` branch to
+the new pinned image version. Failed releases must not advance that branch.
+
+Portainer sees the branch change at its next polling interval and replaces Crowbarr
+using the same storage mounts. Source commits on `main` do not trigger this stack.
+An audit-policy-only change does not publish a new application version.
+
+To pause updates, disable GitOps polling. To pin one version, set
+`CROWBARR_IMAGE_TAG` to its number without `v` or `-cuda`; remove the variable to
+follow releases again. Read release notes and maintain recoverable backups.
+Automatic replacement is not automatic database rollback.

--- a/packaging/install-crowbarr.sh
+++ b/packaging/install-crowbarr.sh
@@ -1,28 +1,100 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 022
 
-REPOSITORY="amanofvaly/crowbarr"
-INSTALL_DIR="${CROWBARR_INSTALL_DIR:-/opt/crowbarr}"
-DATA_DIR="${CROWBARR_DATA_DIR:-/var/lib/crowbarr}"
-SERVICE_USER="${CROWBARR_USER:-${SUDO_USER:-$(id -un)}}"
-SERVICE_GROUP="${CROWBARR_GROUP:-$(id -gn "$SERVICE_USER" 2>/dev/null || echo "$SERVICE_USER")}"
-RELEASE="${CROWBARR_VERSION:-latest}"
+REPOSITORY=amanofvaly/crowbarr
+CONFIG_DIR=/etc/crowbarr
+CONFIG_FILE=$CONFIG_DIR/installer.env
+UNIT_DIR=/etc/systemd/system
+UPDATER=/usr/local/sbin/crowbarr-update
 LATEST_URL="https://github.com/$REPOSITORY/releases/latest/download"
+fail() { echo "$*" >&2; exit 1; }
 
-if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
-  echo "Crowbarr's native installer currently supports Linux x86_64." >&2
-  exit 1
+[[ "$(uname -s)" == Linux && "$(uname -m)" == x86_64 ]] || fail "Native installs require Linux x86_64."
+[[ "$EUID" -eq 0 ]] || fail "Run this installer with sudo."
+for command in systemctl flock stat install mktemp tar sha256sum getent readlink; do
+  command -v "$command" >/dev/null || fail "Missing prerequisite: $command"
+done
+[[ -d /run/systemd/system ]] || fail "A running systemd system is required."
+systemctl show --property=Version --value >/dev/null || fail "Cannot contact systemd."
+exec 9>/run/lock/crowbarr-install.lock
+flock -n 9 || fail "Another Crowbarr install is running."
+
+# Settings are data, never shell code. Only validated, unquoted values are written.
+secure_path() {
+  local path=$1 mode
+  while [[ "$path" != / ]]; do
+    [[ ! -L "$path" ]] || fail "Refusing symlink in privileged path: $path"
+    if [[ -e "$path" ]]; then
+      [[ "$(stat -c %u "$path")" == 0 ]] || fail "Privileged path must be root-owned: $path"
+      mode=$(stat -c %a "$path")
+      (( (8#$mode & 0022) == 0 )) || fail "Privileged path must not be writable by other users: $path"
+    fi
+    path=$(dirname "$path")
+  done
+}
+secure_path "$CONFIG_FILE"
+secure_path "$UNIT_DIR"
+secure_path "$UPDATER"
+if [[ -f "$CONFIG_FILE" ]]; then
+  while IFS='=' read -r key value || [[ -n "$key" ]]; do
+    case "$key" in
+      CROWBARR_USER|CROWBARR_GROUP|CROWBARR_DATA_DIR|CROWBARR_INSTALL_DIR|CROWBARR_AUTO_UPDATE)
+        [[ -n "$value" ]] || fail "Empty setting: $key"
+        if ! declare -p "$key" >/dev/null 2>&1; then printf -v "$key" '%s' "$value"; fi ;;
+      *) fail "Unknown installer setting: $key" ;;
+    esac
+  done < "$CONFIG_FILE"
+elif [[ -f "$UNIT_DIR/crowbarr.service" ]]; then
+  # Migrate the exact unit format written by the previous native installer.
+  while IFS= read -r line; do
+    case "$line" in
+      User=*) CROWBARR_USER=${CROWBARR_USER-${line#User=}} ;;
+      Group=*) CROWBARR_GROUP=${CROWBARR_GROUP-${line#Group=}} ;;
+      Environment=CROWBARR_DATA=*) CROWBARR_DATA_DIR=${CROWBARR_DATA_DIR-${line#Environment=CROWBARR_DATA=}} ;;
+      ExecStart=*/crowbarr\ --host*)
+        legacy_path=${line#ExecStart=}
+        CROWBARR_INSTALL_DIR=${CROWBARR_INSTALL_DIR-${legacy_path%/crowbarr --host*}} ;;
+    esac
+  done < "$UNIT_DIR/crowbarr.service"
+  [[ -n ${CROWBARR_USER:-} && -n ${CROWBARR_GROUP:-} && -n ${CROWBARR_DATA_DIR:-} && -n ${CROWBARR_INSTALL_DIR:-} ]] ||
+    fail "Cannot migrate custom service; specify CROWBARR_USER/GROUP/DATA_DIR/INSTALL_DIR explicitly."
 fi
 
-if [[ "$EUID" -ne 0 ]]; then
-  echo "Run this installer with sudo." >&2
-  exit 1
+SERVICE_USER=${CROWBARR_USER-crowbarr}
+INSTALL_DIR=${CROWBARR_INSTALL_DIR-/opt/crowbarr}
+DATA_DIR=${CROWBARR_DATA_DIR-/var/lib/crowbarr}
+AUTO_UPDATE=${CROWBARR_AUTO_UPDATE-false}
+RELEASE=${CROWBARR_VERSION-latest}
+[[ "$SERVICE_USER" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*\$?$ ]] || fail "Invalid CROWBARR_USER."
+[[ "$AUTO_UPDATE" == true || "$AUTO_UPDATE" == false ]] || fail "CROWBARR_AUTO_UPDATE must be true or false."
+[[ "$RELEASE" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]] || fail "Invalid CROWBARR_VERSION."
+for path in "$INSTALL_DIR" "$DATA_DIR"; do
+  [[ "$path" =~ ^/[-a-zA-Z0-9_./]+$ && "$path" != / && "$path" != */ && "$path" != *//* && "$path" != */../* && "$path" != */.. && "$path" != */./* && "$path" != */. ]] ||
+    fail "Install/data paths must be absolute, normalized paths without spaces or shell/systemd metacharacters."
+done
+VERSIONS_DIR=${INSTALL_DIR}.versions
+[[ "$DATA_DIR" != "$INSTALL_DIR" && "$DATA_DIR" != "$INSTALL_DIR/"* && "$INSTALL_DIR" != "$DATA_DIR/"* && "$DATA_DIR" != "$VERSIONS_DIR" && "$DATA_DIR" != "$VERSIONS_DIR/"* ]] ||
+  fail "Install and data directories must be separate."
+secure_path "$(dirname "$INSTALL_DIR")"
+secure_path "$VERSIONS_DIR"
+if [[ -L "$INSTALL_DIR" ]]; then
+  secure_path "$(readlink -f "$INSTALL_DIR")"
+else
+  secure_path "$INSTALL_DIR"
 fi
 
 if ! id "$SERVICE_USER" >/dev/null 2>&1; then
-  echo "User $SERVICE_USER does not exist." >&2
-  exit 1
+  [[ "$SERVICE_USER" == crowbarr ]] || fail "User $SERVICE_USER does not exist."
+  command -v useradd >/dev/null || fail "Missing prerequisite: useradd"
+  command -v groupadd >/dev/null || fail "Missing prerequisite: groupadd"
+  getent group crowbarr >/dev/null || groupadd --system crowbarr
+  useradd --system --gid crowbarr --home-dir "$DATA_DIR" --no-create-home --shell /usr/sbin/nologin crowbarr
 fi
+[[ ${CROWBARR_USER+x} || "$(id -u "$SERVICE_USER")" != 0 ]] || fail "Default crowbarr account must be nonroot."
+SERVICE_GROUP=${CROWBARR_GROUP-$(id -gn "$SERVICE_USER")}
+[[ "$SERVICE_GROUP" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*\$?$ ]] || fail "Invalid CROWBARR_GROUP."
+getent group "$SERVICE_GROUP" >/dev/null || fail "Group $SERVICE_GROUP does not exist."
 
 install_packages() {
   if command -v apt-get >/dev/null 2>&1; then
@@ -31,45 +103,123 @@ install_packages() {
   elif command -v dnf >/dev/null 2>&1; then
     dnf install -y ca-certificates curl ffmpeg libgomp
   elif command -v pacman >/dev/null 2>&1; then
-    pacman -Sy --needed --noconfirm ca-certificates curl ffmpeg gcc-libs
+    pacman -S --needed --noconfirm ca-certificates curl ffmpeg gcc-libs
   elif command -v zypper >/dev/null 2>&1; then
     zypper --non-interactive install ca-certificates curl ffmpeg libgomp1
   else
-    echo "Install curl, ffmpeg, and ffprobe, then run this installer again." >&2
-    exit 1
+    fail "Install curl, ffmpeg, ffprobe and the OpenMP runtime, then retry."
   fi
 }
+if ! command -v curl >/dev/null || ! command -v ffmpeg >/dev/null || ! command -v ffprobe >/dev/null; then install_packages; fi
+for command in curl ffmpeg ffprobe; do
+  command -v "$command" >/dev/null || fail "Missing prerequisite after package installation: $command"
+done
 
-if ! command -v curl >/dev/null 2>&1 || ! command -v ffmpeg >/dev/null 2>&1 || ! command -v ffprobe >/dev/null 2>&1; then
-  install_packages
+RELEASE_URL=$LATEST_URL
+[[ "$RELEASE" == latest ]] || RELEASE_URL="https://github.com/$REPOSITORY/releases/download/v${RELEASE#v}"
+TEMP_DIR=$(mktemp -d)
+NEW_VERSION=
+OLD_VERSION=
+TRANSACTION=false
+SWITCHED=false
+WAS_ACTIVE=false
+WAS_ENABLED=false
+TIMER_ENABLED=false
+TIMER_ACTIVE=false
+systemctl is-active --quiet crowbarr.service && WAS_ACTIVE=true
+systemctl is-enabled --quiet crowbarr.service && WAS_ENABLED=true
+systemctl is-enabled --quiet crowbarr-update.timer && TIMER_ENABLED=true
+systemctl is-active --quiet crowbarr-update.timer && TIMER_ACTIVE=true
+FILES=("$UNIT_DIR/crowbarr.service" "$UNIT_DIR/crowbarr-update.service" "$UNIT_DIR/crowbarr-update.timer" "$CONFIG_FILE" "$UPDATER")
+for i in "${!FILES[@]}"; do
+  [[ ! -e "${FILES[$i]}" ]] || cp -p "${FILES[$i]}" "$TEMP_DIR/backup.$i"
+done
+finish() {
+  local result=$?
+  trap - EXIT INT TERM
+  set +e
+  if $TRANSACTION; then
+    echo "Install failed; restoring the previous binary and service settings." >&2
+    systemctl stop crowbarr.service
+    if $SWITCHED && [[ -n "$OLD_VERSION" ]]; then
+      ln -s "$OLD_VERSION" "$VERSIONS_DIR/rollback.$$" &&
+        mv -Tf "$VERSIONS_DIR/rollback.$$" "$INSTALL_DIR"
+    elif $SWITCHED; then
+      rm -f "$INSTALL_DIR"
+    fi
+    for i in "${!FILES[@]}"; do
+      if [[ -f "$TEMP_DIR/backup.$i" ]]; then cp -p "$TEMP_DIR/backup.$i" "${FILES[$i]}"; else rm -f "${FILES[$i]}"; fi
+    done
+    systemctl daemon-reload
+    if $WAS_ENABLED; then systemctl enable crowbarr.service; else systemctl disable crowbarr.service; fi
+    if $WAS_ACTIVE; then systemctl start crowbarr.service || echo "Previous service could not restart; inspect journalctl -u crowbarr." >&2; fi
+    systemctl disable --now crowbarr-update.timer 2>/dev/null
+    if $TIMER_ENABLED; then systemctl enable crowbarr-update.timer; fi
+    if $TIMER_ACTIVE; then systemctl start crowbarr-update.timer; fi
+  fi
+  # Do not delete a binary still referenced if restoring the symlink failed.
+  if [[ -n "$NEW_VERSION" && "$(readlink -f "$INSTALL_DIR")" != "$NEW_VERSION/crowbarr" ]]; then rm -rf "$NEW_VERSION"; fi
+  rm -rf "$TEMP_DIR"
+  exit "$result"
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+curl -fL --retry 3 "$RELEASE_URL/crowbarr-linux-x86_64.tar.gz.sha256" -o "$TEMP_DIR/checksum"
+read -r checksum _ < "$TEMP_DIR/checksum"
+[[ "$checksum" =~ ^[a-fA-F0-9]{64}$ ]] || fail "Invalid release checksum."
+TARGET_VERSION=$VERSIONS_DIR/$checksum
+cat > "$TEMP_DIR/settings" <<EOF
+CROWBARR_USER=$SERVICE_USER
+CROWBARR_GROUP=$SERVICE_GROUP
+CROWBARR_DATA_DIR=$DATA_DIR
+CROWBARR_INSTALL_DIR=$INSTALL_DIR
+CROWBARR_AUTO_UPDATE=$AUTO_UPDATE
+EOF
+if [[ -L "$INSTALL_DIR" && "$(readlink -f "$INSTALL_DIR")" == "$TARGET_VERSION/crowbarr" ]] &&
+   [[ -x "$INSTALL_DIR/crowbarr" && -f "$UPDATER" && -f "$UNIT_DIR/crowbarr.service" ]] &&
+   cmp -s "$TEMP_DIR/settings" "$CONFIG_FILE" && $WAS_ACTIVE; then
+  echo "Crowbarr is already up to date."
+  exit 0
 fi
-
-if [[ "$RELEASE" == "latest" ]]; then
-  RELEASE_URL="$LATEST_URL"
-else
-  RELEASE_URL="https://github.com/$REPOSITORY/releases/download/v${RELEASE#v}"
+curl -fL --retry 3 "$RELEASE_URL/crowbarr-linux-x86_64.tar.gz" -o "$TEMP_DIR/package.tar.gz"
+(cd "$TEMP_DIR"; printf '%s  package.tar.gz\n' "$checksum" | sha256sum -c -)
+# Fetch before downtime; this also supports curl | sudo bash installation.
+curl -fL --retry 3 "$RELEASE_URL/install-crowbarr.sh" -o "$TEMP_DIR/updater"
+bash -n "$TEMP_DIR/updater"
+install -d -m 0755 "$VERSIONS_DIR"
+secure_path "$TARGET_VERSION"
+if [[ ! -d "$TARGET_VERSION" ]]; then
+  NEW_VERSION=$(mktemp -d "$VERSIONS_DIR/release.XXXXXXXX")
+  chmod 0755 "$NEW_VERSION"
+  tar --extract --gzip --file "$TEMP_DIR/package.tar.gz" --directory "$NEW_VERSION" --no-same-owner
+  [[ -x "$NEW_VERSION/crowbarr/crowbarr" ]] || fail "Release has no executable crowbarr/crowbarr."
+  chown -R root:root "$NEW_VERSION"
+  chmod -R go-w "$NEW_VERSION"
+  mv "$NEW_VERSION" "$TARGET_VERSION"
+  NEW_VERSION=$TARGET_VERSION
 fi
+[[ -x "$TARGET_VERSION/crowbarr/crowbarr" ]] || fail "Installed release has no executable."
+install -d -m 0755 "$CONFIG_DIR" "$(dirname "$UPDATER")"
+if [[ ! -d "$DATA_DIR" ]]; then install -d -m 0700 -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$DATA_DIR"; fi
 
-TEMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TEMP_DIR"' EXIT
+if [[ -L "$INSTALL_DIR" ]]; then
+  OLD_VERSION=$(readlink -f "$INSTALL_DIR")
+elif [[ -e "$INSTALL_DIR" ]]; then
+  OLD_VERSION="$VERSIONS_DIR/legacy.$(date +%s).$$"
+fi
+TRANSACTION=true
+if [[ -f "$UNIT_DIR/crowbarr.service" ]]; then systemctl stop crowbarr.service; fi
+if [[ -d "$INSTALL_DIR" && ! -L "$INSTALL_DIR" ]]; then
+  mv "$INSTALL_DIR" "$OLD_VERSION"
+  SWITCHED=true
+fi
+ln -s "$TARGET_VERSION/crowbarr" "$VERSIONS_DIR/current.$$"
+mv -Tf "$VERSIONS_DIR/current.$$" "$INSTALL_DIR"
+SWITCHED=true
 
-curl -fL "$RELEASE_URL/crowbarr-linux-x86_64.tar.gz" -o "$TEMP_DIR/crowbarr-linux-x86_64.tar.gz"
-curl -fL "$RELEASE_URL/crowbarr-linux-x86_64.tar.gz.sha256" -o "$TEMP_DIR/crowbarr-linux-x86_64.tar.gz.sha256"
-(
-  cd "$TEMP_DIR"
-  sha256sum -c crowbarr-linux-x86_64.tar.gz.sha256
-  tar -xzf crowbarr-linux-x86_64.tar.gz
-)
-
-systemctl stop crowbarr.service 2>/dev/null || true
-rm -rf "${INSTALL_DIR}.new"
-mv "$TEMP_DIR/crowbarr" "${INSTALL_DIR}.new"
-rm -rf "$INSTALL_DIR"
-mv "${INSTALL_DIR}.new" "$INSTALL_DIR"
-
-install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$DATA_DIR"
-
-cat > /etc/systemd/system/crowbarr.service <<EOF
+cat > "$UNIT_DIR/crowbarr.service" <<EOF
 [Unit]
 Description=Crowbarr subtitle service
 After=network-online.target
@@ -89,22 +239,55 @@ TimeoutStopSec=45
 [Install]
 WantedBy=multi-user.target
 EOF
+cat > "$TEMP_DIR/settings" <<EOF
+CROWBARR_USER=$SERVICE_USER
+CROWBARR_GROUP=$SERVICE_GROUP
+CROWBARR_DATA_DIR=$DATA_DIR
+CROWBARR_INSTALL_DIR=$INSTALL_DIR
+CROWBARR_AUTO_UPDATE=$AUTO_UPDATE
+EOF
+install -o root -g root -m 0600 "$TEMP_DIR/settings" "$CONFIG_FILE"
+install -o root -g root -m 0755 "$TEMP_DIR/updater" "$UPDATER"
+cat > "$UNIT_DIR/crowbarr-update.service" <<EOF
+[Unit]
+Description=Update Crowbarr native installation
+Wants=network-online.target
+After=network-online.target
 
-curl -fL "$LATEST_URL/install-crowbarr.sh" -o /usr/local/sbin/crowbarr-update
-chmod 0755 /usr/local/sbin/crowbarr-update
+[Service]
+Type=oneshot
+ExecStart=$UPDATER
+TimeoutStartSec=30min
+EOF
+cat > "$UNIT_DIR/crowbarr-update.timer" <<'EOF'
+[Unit]
+Description=Check daily for Crowbarr updates
 
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
 systemctl daemon-reload
 systemctl enable --now crowbarr.service
-
+healthy=false
 for _ in {1..20}; do
-  if curl -fsS http://127.0.0.1:8449/health >/dev/null; then
-    echo "Crowbarr is running at http://localhost:8449"
-    echo "Update later with: sudo crowbarr-update"
-    exit 0
+  if systemctl is-active --quiet crowbarr.service && curl -fsS --connect-timeout 2 --max-time 3 http://127.0.0.1:8449/health >/dev/null; then
+    healthy=true
+    break
   fi
   sleep 1
 done
-
-systemctl status crowbarr.service --no-pager || true
-echo "Crowbarr was installed, but its health check did not pass." >&2
-exit 1
+$healthy || fail "New release failed its health check. Data is preserved; binary rollback cannot undo database migrations."
+if [[ "$AUTO_UPDATE" == true ]]; then
+  systemctl enable --now crowbarr-update.timer
+else
+  systemctl disable --now crowbarr-update.timer
+fi
+TRANSACTION=false
+NEW_VERSION= # Retain installed versions, including the previous working binary.
+echo "Crowbarr is running at http://localhost:8449"
+echo "Update with: sudo crowbarr-update (settings: $CONFIG_FILE; auto-update: $AUTO_UPDATE)"

--- a/packaging/package_entry.py
+++ b/packaging/package_entry.py
@@ -1,0 +1,15 @@
+"""Frozen entry point, including a model-free release validation command."""
+
+import multiprocessing
+import sys
+
+from packaging_smoke import smoke
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    if sys.argv[1:] == ["--packaging-smoke"]:
+        smoke()
+    else:
+        from crowbarr.__main__ import main
+
+        main()

--- a/packaging/packaging_smoke.py
+++ b/packaging/packaging_smoke.py
@@ -1,0 +1,76 @@
+"""Exercise installed/frozen imports and real job processing in a spawned child.
+
+No models or user media are needed. This validates packaging, not model accuracy
+or GPU execution. Missing alignment imports must fail instead of being softened
+into the processor's optional-refinement warning.
+"""
+
+import multiprocessing
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def check_imports():
+    import ctranslate2
+    import faster_whisper
+    import torch
+    import torchaudio
+    from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
+    from whisperx.alignment import align, load_align_model
+
+    assert all((ctranslate2, faster_whisper, torchaudio, Wav2Vec2ForCTC, Wav2Vec2Processor))
+    assert callable(align) and callable(load_align_model)
+    assert torch.ones(2).sum().item() == 2
+
+
+def process_fixture(directory, check_inference=True):
+    if check_inference:
+        check_imports()
+    from crowbarr.config import Settings
+    from crowbarr.db import Database
+    from crowbarr.library import scan
+    from crowbarr.service import run_job
+
+    root = Path(directory)
+    media = root / "library" / "fixture.mkv"
+    media.parent.mkdir()
+    subprocess.run(
+        ["ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=s=160x90:d=1",
+         "-f", "lavfi", "-i", "sine=frequency=440:duration=1", "-c:v", "mpeg4",
+         "-c:a", "pcm_s16le", "-metadata:s:a:0", "language=eng", "-shortest", str(media)],
+        check=True, timeout=30,
+    )
+    media.with_suffix(".en.srt").write_text("not a valid subtitle", encoding="utf-8")
+    settings = Settings(roots=[str(media.parent)], settle_seconds=0, subtitle_wait_minutes=0)
+    state = root / "state"
+    db = Database(state / "crowbarr.db")
+    scan(settings, db)
+    job = db.claim()
+    assert job, "Fixture was not discovered and queued"
+    run_job(str(state), job, settings.model_dump())
+    result = db.get(job["id"])
+    assert result["state"] == "review", result
+    assert "No discovered subtitle source could be read" in result["error"], result
+    assert not media.with_suffix(".crowbarr.en.srt").exists()
+
+
+def smoke(check_inference=True):
+    with tempfile.TemporaryDirectory(prefix="crowbarr-package-") as directory:
+        child = multiprocessing.get_context("spawn").Process(
+            target=process_fixture, args=(directory, check_inference)
+        )
+        child.start()
+        child.join(timeout=180)
+        if child.is_alive():
+            child.kill()
+            child.join()
+            raise RuntimeError("Packaging child timed out")
+        assert child.exitcode == 0, f"Packaging child exited {child.exitcode}"
+        child.close()
+    print("Packaging imports and spawned job processing passed", flush=True)
+
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    smoke()

--- a/packaging/packaging_smoke.py
+++ b/packaging/packaging_smoke.py
@@ -1,8 +1,8 @@
-"""Exercise installed/frozen imports and real job processing in a spawned child.
+"""Exercise packaged inference and real job processing in a spawned child.
 
-No models or user media are needed. This validates packaging, not model accuracy
-or GPU execution. Missing alignment imports must fail instead of being softened
-into the processor's optional-refinement warning.
+Release checks download the tiny speech model and decode generated audio on CPU.
+This validates packaging, not recognition accuracy or GPU execution. Missing
+alignment imports fail instead of becoming an optional-refinement warning.
 """
 
 import multiprocessing
@@ -33,6 +33,17 @@ def process_fixture(directory, check_inference=True):
     from crowbarr.service import run_job
 
     root = Path(directory)
+    if check_inference:
+        import numpy as np
+        from faster_whisper import WhisperModel
+
+        model = WhisperModel("tiny", device="cpu", compute_type="int8", cpu_threads=2,
+                             download_root=str(root / "models"))
+        audio = (0.1 * np.sin(2 * np.pi * 440 * np.arange(16000) / 16000)).astype(np.float32)
+        segments, _ = model.transcribe(audio, language="en", beam_size=1, vad_filter=False)
+        # Exhaust the lazy iterator to execute the encoder and decoder.
+        list(segments)
+        del model
     media = root / "library" / "fixture.mkv"
     media.parent.mkdir()
     subprocess.run(

--- a/packaging/release_tools.py
+++ b/packaging/release_tools.py
@@ -1,0 +1,144 @@
+"""Release validation and deploy-manifest generation. No server access."""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tarfile
+from pathlib import Path, PurePosixPath
+
+
+def version_tuple(value):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", value):
+        raise ValueError(f"Invalid release version: {value!r}")
+    return tuple(map(int, value.split(".")))
+
+
+def command(*args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def guard():
+    # Fetch failure is fatal: never treat unavailable remote state as permission.
+    command("git", "fetch", "origin", "main")
+    source = command("git", "show", "origin/main:crowbarr/version.py")
+    current = Path("crowbarr/version.py").read_text()
+    pattern = r'^APPLICATION_VERSION\s*=\s*[\'"]([^\'"]+)[\'"]'
+    expected = re.search(pattern, current, re.MULTILINE).group(1)
+    actual = re.search(pattern, source, re.MULTILINE).group(1)
+    version_tuple(expected)
+    if actual != expected:
+        raise ValueError(f"Stale release {expected}; main now selects {actual}")
+    subprocess.run(["git", "merge-base", "--is-ancestor", os.environ["GITHUB_SHA"], "origin/main"], check=True)
+    releases = json.loads(command(
+        "gh", "api", "--paginate", "--slurp", f"repos/{os.environ['GITHUB_REPOSITORY']}/releases"
+    ))
+    for page in releases:
+        for release in page:
+            tag = release["tag_name"].removeprefix("v")
+            if not release["draft"] and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", tag):
+                if version_tuple(tag) > version_tuple(expected):
+                    raise ValueError(f"Refusing to promote {expected} after published {tag}")
+
+
+def verify_assets(directory):
+    directory = Path(directory)
+    name = "crowbarr-linux-x86_64.tar.gz"
+    expected = {name, name + ".sha256", "install-crowbarr.sh"}
+    if {p.name for p in directory.iterdir()} != expected:
+        raise ValueError("Unexpected or missing release assets")
+    checksum = (directory / (name + ".sha256")).read_text().split()
+    with (directory / name).open("rb") as stream:
+        digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    if checksum != [digest, name]:
+        raise ValueError("Native archive checksum mismatch")
+    with tarfile.open(directory / name) as archive:
+        members = archive.getmembers()
+        names = {member.name for member in members}
+        if not {"crowbarr/crowbarr", "crowbarr/LICENSE"} <= names:
+            raise ValueError("Archive lacks executable or license")
+        for member in members:
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts or path.parts[0] != "crowbarr":
+                raise ValueError(f"Unsafe archive path: {member.name}")
+            if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
+                raise ValueError(f"Unexpected archive member: {member.name}")
+            if member.issym() or member.islnk():
+                target = PurePosixPath(member.linkname)
+                if target.is_absolute() or ".." in target.parts:
+                    raise ValueError(f"Unsafe archive link: {member.name}")
+
+
+def verify_digests(directory):
+    directory = Path(directory)
+    expected = {"cpu-amd64", "cuda-amd64"}
+    if {p.name for p in directory.iterdir()} != expected:
+        raise ValueError("Missing or unexpected image verification results")
+    image = "ghcr.io/" + os.environ["GITHUB_REPOSITORY"].lower()
+    for name in expected:
+        ref = (directory / name).read_text().strip()
+        if not re.fullmatch(re.escape(image) + r"@sha256:[a-f0-9]{64}", ref):
+            raise ValueError(f"Invalid verified image digest: {name}")
+        command("docker", "buildx", "imagetools", "inspect", ref)
+
+
+def version_image(tag, *digest_files):
+    refs = [Path(path).read_text().strip() for path in digest_files]
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", tag, "--raw"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        manifest = json.loads(result.stdout)
+        actual = {item["digest"] for item in manifest.get("manifests", [])}
+        expected = {ref.split("@", 1)[1] for ref in refs}
+        if actual != expected:
+            raise ValueError(f"Refusing to overwrite existing immutable version {tag}")
+        return
+    # Auth/network errors must never be mistaken for an absent immutable tag.
+    if "not found" not in result.stderr.lower() and "manifest unknown" not in result.stderr.lower():
+        raise RuntimeError(result.stderr)
+    subprocess.run(["docker", "buildx", "imagetools", "create", "-t", tag, *refs], check=True)
+
+
+def manifests(version, output, source=Path(".")):
+    version_tuple(version)
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=False)
+    for name in ("compose.yaml", "compose.cuda.yaml", "compose.extra-media.yaml"):
+        text = (source / name).read_text()
+        if name != "compose.extra-media.yaml":
+            if text.count("${CROWBARR_IMAGE_TAG:-latest}") != 1:
+                raise ValueError(f"Expected exactly one image version default in {name}")
+            text = text.replace("${CROWBARR_IMAGE_TAG:-latest}", "${CROWBARR_IMAGE_TAG:-" + version + "}")
+        (output / name).write_text(text)
+    for name in (
+        "README.md", "CHANGELOG.md", "CONTRIBUTING.md", "LICENSE", ".env.example",
+        "workflow.html", "docs/docker.md", "docs/nas.md", "docs/migration.md",
+        "docs/linux.md", "integrations/bazarr-notify.py",
+    ):
+        path = source / name
+        if path.exists():
+            text = path.read_text()
+            if name == ".env.example":
+                text = re.sub(r"(?m)^(#\s*)?CROWBARR_IMAGE_TAG=.*$", "# CROWBARR_IMAGE_TAG=" + version, text)
+            (output / name).parent.mkdir(parents=True, exist_ok=True)
+            (output / name).write_text(text)
+    (output / "release.json").write_text(json.dumps({
+        "version": version, "commit": os.environ.get("GITHUB_SHA", ""),
+    }, indent=2) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["guard", "verify-assets", "verify-digests", "manifests", "version-image"])
+    parser.add_argument("arguments", nargs="*")
+    args = parser.parse_args()
+    {"guard": guard, "verify-assets": verify_assets, "verify-digests": verify_digests,
+     "manifests": manifests, "version-image": version_image}[args.action](*args.arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,72 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def compose():
+    if not shutil.which("docker"):
+        pytest.skip("Docker Compose is unavailable")
+    available = subprocess.run(["docker", "compose", "version"], capture_output=True)
+    if available.returncode:
+        pytest.skip("Docker Compose is unavailable")
+
+    def render(values, *extra):
+        environment = {k: v for k, v in os.environ.items() if not k.startswith("CROWBARR_")}
+        environment.update(values)
+        command = ["docker", "compose", "--env-file", "/dev/null", "-f", str(ROOT / "compose.yaml")]
+        for name in extra:
+            command.extend(["-f", str(ROOT / name)])
+        return subprocess.run(
+            [*command, "config", "--format", "json"], env=environment,
+            capture_output=True, text=True, check=False,
+        )
+
+    return render
+
+
+def test_missing_persistent_storage_fails_before_deployment(compose):
+    result = compose({})
+    assert result.returncode != 0
+    assert "CROWBARR_CONFIG_DIR" in result.stderr
+
+
+def test_single_library_install_keeps_data_outside_git_checkout(compose):
+    result = compose({"CROWBARR_CONFIG_DIR": "/srv/app/config", "CROWBARR_MEDIA_DIR": "/srv/media"})
+    assert result.returncode == 0, result.stderr
+    service = json.loads(result.stdout)["services"]["crowbarr"]
+    assert service["user"] == "1000:1000"
+    assert service["init"] is True
+    assert "container_name" not in service
+    mounts = {mount["target"]: mount for mount in service["volumes"]}
+    assert mounts["/config"]["source"] == "/srv/app/config"
+    assert mounts["/media"]["source"] == "/srv/media"
+    assert all(not mount["bind"].get("create_host_path", False) for mount in mounts.values())
+
+
+def test_gpu_migration_preserves_existing_paths_identity_and_version(compose):
+    result = compose(
+        {
+            "CROWBARR_CONFIG_DIR": "/srv/existing/config",
+            "CROWBARR_MEDIA_DIR": "/srv/television",
+            "CROWBARR_MEDIA_MOUNT": "/tv",
+            "CROWBARR_EXTRA_MEDIA_DIR": "/srv/movies",
+            "CROWBARR_EXTRA_MEDIA_MOUNT": "/movies",
+            "CROWBARR_UID": "568", "CROWBARR_GID": "568",
+            "CROWBARR_IMAGE_TAG": "1.2.3", "CROWBARR_PORT": "18449",
+        },
+        "compose.cuda.yaml", "compose.extra-media.yaml",
+    )
+    assert result.returncode == 0, result.stderr
+    service = json.loads(result.stdout)["services"]["crowbarr"]
+    assert service["user"] == "568:568"
+    assert service["image"] == "ghcr.io/amanofvaly/crowbarr:1.2.3-cuda"
+    assert service["ports"][0]["published"] == "18449"
+    assert {m["target"] for m in service["volumes"]} == {"/config", "/tv", "/movies"}
+    assert service["deploy"]["resources"]["reservations"]["devices"][0]["capabilities"] == ["gpu"]

--- a/tests/test_native_installer.py
+++ b/tests/test_native_installer.py
@@ -1,0 +1,316 @@
+"""Run the real installer control flow without root, Linux, network or systemd.
+
+Only fixed system paths/EUID are redirected in a temporary copy. Host-specific
+commands are mocked; actual files, symlink switches and archive checks are exercised.
+"""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+INSTALLER = Path(__file__).resolve().parents[1] / "packaging/install-crowbarr.sh"
+MOCK = r'''
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tarfile
+
+name = Path(sys.argv[0]).name
+args = sys.argv[1:]
+root = Path(os.environ["HARNESS_ROOT"])
+with (root / "commands").open("a") as log:
+    log.write(json.dumps([name, *args]) + "\n")
+state_file = root / "state.json"
+state = json.loads(state_file.read_text())
+
+def save():
+    state_file.write_text(json.dumps(state))
+
+if name == "uname":
+    print("Linux" if args == ["-s"] else "x86_64")
+elif name == "stat":
+    if args[1] == "%u":
+        print("1000" if os.environ.get("UNSAFE_OWNER") == args[-1] else "0")
+    else:
+        # Real leaf permissions; virtual root ancestors belong to the test runner.
+        path = Path(args[-1])
+        print(oct(path.stat().st_mode & 0o777)[2:] if path.is_relative_to(root) else "755")
+elif name == "flock":
+    sys.exit(int(os.environ.get("LOCKED", "0")))
+elif name == "id":
+    user = args[-1]
+    if user not in state["users"]:
+        sys.exit(1)
+    print(user if args[0] == "-gn" else "0" if user == "root" else "999")
+elif name == "getent":
+    sys.exit(0 if args[-1] in state["groups"] else 2)
+elif name in ("useradd", "groupadd"):
+    state["users" if name == "useradd" else "groups"].append(args[-1])
+    save()
+elif name == "systemctl":
+    action = args[0]
+    unit = args[-1]
+    if action == "show":
+        sys.exit(int(os.environ.get("NO_SYSTEMD", "0")))
+    active = state.setdefault("active", [])
+    enabled = state.setdefault("enabled", [])
+    if action in ("is-active", "is-enabled"):
+        sys.exit(0 if unit in (active if action == "is-active" else enabled) else 1)
+    if action == "enable":
+        if "--now" in args and os.environ.get("FAIL_START") and not state.get("failed_once"):
+            state["failed_once"] = True
+            save()
+            sys.exit(1)
+        if unit not in enabled:
+            enabled.append(unit)
+    if action in ("start", "restart") or (action == "enable" and "--now" in args):
+        if unit not in active:
+            active.append(unit)
+    if action == "stop" or (action == "disable" and "--now" in args):
+        if unit in active:
+            active.remove(unit)
+    if action == "disable" and unit in enabled:
+        enabled.remove(unit)
+    save()
+elif name == "curl":
+    url = next(arg for arg in args if arg.startswith("http"))
+    if url.endswith("/health"):
+        sys.exit(int(os.environ.get("BAD_HEALTH", "0")))
+    if os.environ.get("FAIL_DOWNLOAD") and url.endswith(os.environ["FAIL_DOWNLOAD"]):
+        sys.exit(22)
+    dest = Path(args[args.index("-o") + 1])
+    if url.endswith(".sha256"):
+        digest = hashlib.sha256((root / "package.tar.gz").read_bytes()).hexdigest()
+        dest.write_text(("0" * 64 if os.environ.get("BAD_CHECKSUM") else digest) + "  crowbarr-linux-x86_64.tar.gz\n")
+    else:
+        shutil.copyfile(root / ("installer.sh" if url.endswith(".sh") else "package.tar.gz"), dest)
+elif name == "sha256sum":
+    expected, path = sys.stdin.read().split()
+    sys.exit(0 if hashlib.sha256(Path(path).read_bytes()).hexdigest() == expected else 1)
+elif name == "tar":
+    with tarfile.open(args[args.index("--file") + 1]) as archive:
+        archive.extractall(args[args.index("--directory") + 1], filter="data")
+elif name == "install":
+    mode = 0o755
+    paths = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in ("-o", "-g", "-m"):
+            if arg == "-m":
+                mode = int(args[index + 1], 8)
+            index += 2
+        else:
+            if not arg.startswith("-"):
+                paths.append(Path(arg))
+            index += 1
+    if "-d" in args:
+        for path in paths:
+            path.mkdir(parents=True, exist_ok=True)
+            path.chmod(mode)
+    else:
+        shutil.copyfile(*paths)
+        paths[-1].chmod(mode)
+elif name == "mv":
+    if args[0] == "-Tf":
+        os.replace(args[1], args[2])
+    else:
+        shutil.move(*args)
+elif name == "readlink":
+    print(Path(args[-1]).resolve())
+elif name not in ("chown", "sleep", "ffmpeg", "ffprobe"):
+    raise RuntimeError(f"Unexpected mock: {name}")
+'''
+
+
+class NativeInstaller:
+    def __init__(self, root):
+        self.root = root.resolve()
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.unit = self.root / "etc/systemd/system"
+        self.unit.mkdir(parents=True)
+        (self.root / "run/systemd/system").mkdir(parents=True)
+        (self.root / "run/lock").mkdir()
+        self.config = self.root / "etc/crowbarr/installer.env"
+        self.install = self.root / "opt/crowbarr"
+        self.data = self.root / "var/lib/crowbarr"
+        self.updater = self.root / "usr/local/sbin/crowbarr-update"
+        source = INSTALLER.read_text().replace('"$EUID"', '"0"')
+        for prefix in ("/etc/crowbarr", "/etc/systemd/system", "/usr/local/sbin", "/run/", "/opt/", "/var/lib/"):
+            source = source.replace(prefix, str(self.root) + prefix)
+        self.script = self.root / "installer.sh"
+        self.script.write_text(source)
+        self.state_file = self.root / "state.json"
+        self.state_file.write_text(json.dumps({"users": ["root", "media"], "groups": ["root", "media", "video"]}))
+        for command in (
+            "uname", "stat", "flock", "id", "getent", "useradd", "groupadd", "systemctl",
+            "curl", "sha256sum", "tar", "install", "mv", "readlink", "chown", "sleep", "ffmpeg", "ffprobe",
+        ):
+            path = self.bin / command
+            path.write_text(f"#!{sys.executable}\n" + MOCK)
+            path.chmod(0o755)
+        self.package("first")
+
+    def package(self, version):
+        with tarfile.open(self.root / "package.tar.gz", "w:gz") as archive:
+            data = f"#!/bin/sh\necho {version}\n".encode()
+            entry = tarfile.TarInfo("crowbarr/crowbarr")
+            entry.mode = 0o755
+            entry.size = len(data)
+            archive.addfile(entry, io.BytesIO(data))
+
+    def run(self, *, updater=False, **settings):
+        env = {key: value for key, value in os.environ.items() if not key.startswith("CROWBARR_")}
+        env.update(HARNESS_ROOT=str(self.root), PATH=f"{self.bin}:{os.environ['PATH']}", SUDO_USER="root")
+        env.update({key: str(value) for key, value in settings.items()})
+        return subprocess.run(
+            ["bash", str(self.updater if updater else self.script)], env=env,
+            capture_output=True, text=True, timeout=60,
+        )
+
+    @property
+    def state(self):
+        return json.loads(self.state_file.read_text())
+
+    @property
+    def commands(self):
+        return [json.loads(line) for line in (self.root / "commands").read_text().splitlines()]
+
+
+@pytest.fixture
+def native(tmp_path):
+    return NativeInstaller(tmp_path)
+
+
+def succeeded(result):
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_shell_syntax():
+    subprocess.run(["bash", "-n", str(INSTALLER)], check=True)
+
+
+def test_default_account_and_repeat_install(native):
+    succeeded(native.run())
+    assert native.install.is_symlink()
+    assert "User=crowbarr\nGroup=crowbarr" in (native.unit / "crowbarr.service").read_text()
+    assert native.config.stat().st_mode & 0o777 == 0o600
+    assert "CROWBARR_AUTO_UPDATE=false" in native.config.read_text()
+    assert "crowbarr-update.timer" not in native.state["enabled"]
+    target = native.install.resolve()
+    before = len(native.commands)
+    succeeded(native.run(updater=True))
+    subsequent = native.commands[before:]
+    assert ["systemctl", "stop", "crowbarr.service"] not in subsequent
+    assert not any(cmd[0] == "curl" and any(arg.endswith(".tar.gz") for arg in cmd) for cmd in subsequent)
+    assert native.install.resolve() == target
+    assert native.state["users"].count("crowbarr") == 1
+    assert len(list(native.install.with_suffix(".versions").iterdir())) == 1
+
+
+def test_custom_settings_survive_updater_and_timer_opt_out(native):
+    install = native.root / "custom/app"
+    data = native.root / "custom/data"
+    succeeded(native.run(CROWBARR_USER="media", CROWBARR_GROUP="video", CROWBARR_INSTALL_DIR=install,
+                         CROWBARR_DATA_DIR=data, CROWBARR_AUTO_UPDATE="true"))
+    (data / "crowbarr.db").write_text("persistent data")
+    previous = install.resolve()
+    native.package("second")
+    succeeded(native.run(updater=True))
+    assert install.resolve() != previous
+    assert (previous / "crowbarr").is_file()
+    assert (data / "crowbarr.db").read_text() == "persistent data"
+    assert "User=media\nGroup=video" in (native.unit / "crowbarr.service").read_text()
+    assert "crowbarr-update.timer" in native.state["enabled"]
+    succeeded(native.run(updater=True, CROWBARR_AUTO_UPDATE="false"))
+    assert "crowbarr-update.timer" not in native.state["active"]
+    assert "CROWBARR_AUTO_UPDATE=false" in native.config.read_text()
+
+
+@pytest.mark.parametrize("failure", ["BAD_HEALTH", "FAIL_START"])
+def test_failed_upgrade_restores_binary_settings_and_timer(native, failure):
+    succeeded(native.run(CROWBARR_AUTO_UPDATE="true"))
+    previous = native.install.resolve()
+    files = [native.config, native.updater, *native.unit.iterdir()]
+    originals = {path: path.read_bytes() for path in files}
+    (native.data / "crowbarr.db").write_text("keep me")
+    native.package("broken")
+    result = native.run(updater=True, CROWBARR_AUTO_UPDATE="false", **{failure: "1"})
+    assert result.returncode != 0
+    assert "restoring" in result.stderr
+    assert native.install.resolve() == previous
+    assert {path: path.read_bytes() for path in files} == originals
+    assert (native.data / "crowbarr.db").read_text() == "keep me"
+    assert "crowbarr.service" in native.state["active"]
+    assert "crowbarr-update.timer" in native.state["active"]
+    assert len(list(native.install.with_suffix(".versions").iterdir())) == 1
+
+
+@pytest.mark.parametrize("settings", [{"BAD_CHECKSUM": "1"}, {"FAIL_DOWNLOAD": ".sh"}])
+def test_download_failure_does_not_stop_old_service(native, settings):
+    succeeded(native.run())
+    native.package("second")
+    before = len(native.commands)
+    previous = native.install.resolve()
+    result = native.run(updater=True, **settings)
+    assert result.returncode != 0
+    assert native.install.resolve() == previous
+    assert ["systemctl", "stop", "crowbarr.service"] not in native.commands[before:]
+
+
+def test_legacy_unit_migration(native):
+    native.install.mkdir(parents=True)
+    binary = native.install / "crowbarr"
+    binary.write_text("legacy")
+    binary.chmod(0o755)
+    native.data.mkdir(parents=True)
+    (native.data / "crowbarr.db").write_text("old database")
+    (native.unit / "crowbarr.service").write_text(
+        f"[Service]\nUser=media\nGroup=video\nEnvironment=CROWBARR_DATA={native.data}\n"
+        f"ExecStart={native.install}/crowbarr --host 0.0.0.0 --port 8449\n"
+    )
+    succeeded(native.run())
+    assert "CROWBARR_USER=media" in native.config.read_text()
+    assert "CROWBARR_GROUP=video" in native.config.read_text()
+    assert (native.data / "crowbarr.db").read_text() == "old database"
+    assert next(native.install.with_suffix(".versions").glob("legacy.*/crowbarr")).read_text() == "legacy"
+
+
+@pytest.mark.parametrize("settings", [{"NO_SYSTEMD": "1"}, {"LOCKED": "1"}, {"CROWBARR_USER": "missing"},
+                                     {"CROWBARR_AUTO_UPDATE": "yes"}, {"CROWBARR_DATA_DIR": "/tmp/a%h"}])
+def test_preflight_failure_does_not_download(native, settings):
+    result = native.run(**settings)
+    assert result.returncode != 0
+    assert not any(command[0] == "curl" for command in native.commands)
+
+
+def test_config_is_not_executable_and_must_be_root_owned(native):
+    succeeded(native.run())
+    result = native.run(UNSAFE_OWNER=native.config)
+    assert result.returncode != 0
+    assert "root-owned" in result.stderr
+    marker = native.root / "injected"
+    native.config.write_text(f"CROWBARR_USER=$(touch {marker})\n")
+    result = native.run()
+    assert result.returncode != 0
+    assert not marker.exists()
+
+
+def test_first_install_health_failure_preserves_data_and_removes_service(native):
+    result = native.run(BAD_HEALTH="1")
+    assert result.returncode != 0
+    assert native.data.is_dir()
+    assert not native.install.exists()
+    assert not native.config.exists()
+    assert not (native.unit / "crowbarr.service").exists()
+    assert "crowbarr.service" not in native.state["active"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,118 @@
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "packaging"))
+import packaging_smoke  # noqa: E402
+
+spec = importlib.util.spec_from_file_location("release_tools", ROOT / "packaging/release_tools.py")
+release_tools = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_tools)
+
+
+def assets(directory, extra=None):
+    archive = directory / "crowbarr-linux-x86_64.tar.gz"
+    with tarfile.open(archive, "w:gz") as stream:
+        for name in ["crowbarr/crowbarr", "crowbarr/LICENSE", *([extra] if extra else [])]:
+            member = tarfile.TarInfo(name)
+            member.size = 1
+            stream.addfile(member, io.BytesIO(b"x"))
+    (directory / (archive.name + ".sha256")).write_text(
+        hashlib.sha256(archive.read_bytes()).hexdigest() + "  " + archive.name + "\n"
+    )
+    (directory / "install-crowbarr.sh").write_text("#!/bin/sh\n")
+    return archive
+
+
+def test_archive_validation_checks_checksum_and_paths(tmp_path):
+    archive = assets(tmp_path)
+    release_tools.verify_assets(tmp_path)
+    archive.write_bytes(b"corrupt")
+    with pytest.raises(ValueError, match="checksum"):
+        release_tools.verify_assets(tmp_path)
+    assets(tmp_path, "crowbarr/../../outside")
+    with pytest.raises(ValueError, match="Unsafe archive path"):
+        release_tools.verify_assets(tmp_path)
+
+
+def test_manifest_defaults_are_pinned_without_editing_sources(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    for name, suffix in [("compose.yaml", ""), ("compose.cuda.yaml", "-cuda")]:
+        (source / name).write_text("image: ghcr.io/example/app:${CROWBARR_IMAGE_TAG:-latest}" + suffix)
+    (source / "compose.extra-media.yaml").write_text("volumes: []")
+    (source / ".env.example").write_text("CROWBARR_IMAGE_TAG=latest\n")
+    output = tmp_path / "output"
+    release_tools.manifests("1.2.3", output, source)
+    assert "${CROWBARR_IMAGE_TAG:-1.2.3}-cuda" in (output / "compose.cuda.yaml").read_text()
+    assert "latest" in (source / "compose.yaml").read_text()
+    assert (output / ".env.example").read_text() == "# CROWBARR_IMAGE_TAG=1.2.3\n"
+    assert json.loads((output / "release.json").read_text())["version"] == "1.2.3"
+
+
+def test_release_instructions_keep_local_links_and_do_not_pin_updates(tmp_path):
+    import re
+
+    output = tmp_path / "release"
+    release_tools.manifests("1.2.3", output, ROOT)
+    for name in ("README.md", "CHANGELOG.md", "CONTRIBUTING.md", "docs/docker.md", "docs/nas.md"):
+        page = output / name
+        assert page.exists()
+        for link in re.findall(r"\]\(([^)]+)\)", page.read_text()):
+            if "://" not in link and not link.startswith("#"):
+                assert (page.parent / link.split("#", 1)[0]).exists(), f"Broken link: {name}: {link}"
+    assert not re.search(r"(?m)^CROWBARR_IMAGE_TAG=", (output / ".env.example").read_text())
+
+
+def test_invalid_version_cannot_be_inserted_in_manifests(tmp_path):
+    with pytest.raises(ValueError, match="Invalid release version"):
+        release_tools.manifests("latest", tmp_path / "output")
+
+
+def test_missing_verified_architecture_blocks_release(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_REPOSITORY", "example/app")
+    (tmp_path / "cpu-amd64").write_text("ghcr.io/example/app@sha256:" + "a" * 64)
+    with pytest.raises(ValueError, match="Missing or unexpected"):
+        release_tools.verify_digests(tmp_path)
+
+
+def test_existing_version_is_never_overwritten(tmp_path, monkeypatch):
+    digest = tmp_path / "cpu-amd64"
+    digest.write_text("ghcr.io/example/app@sha256:" + "a" * 64)
+    monkeypatch.setattr(release_tools.subprocess, "run", lambda *a, **kw: subprocess.CompletedProcess(
+        a, 0, json.dumps({"manifests": [{"digest": "sha256:" + "b" * 64}]}), ""
+    ))
+    with pytest.raises(ValueError, match="Refusing to overwrite"):
+        release_tools.version_image("ghcr.io/example/app:1.2.3", digest)
+
+
+def test_release_guard_rejects_newer_published_release(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "crowbarr").mkdir()
+    (tmp_path / "crowbarr/version.py").write_text('APPLICATION_VERSION = "1.2.3"\n')
+    monkeypatch.setenv("GITHUB_SHA", "abc")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "example/app")
+
+    def command(*args):
+        if args[:2] == ("git", "show"):
+            return 'APPLICATION_VERSION = "1.2.3"\n'
+        if args[0] == "gh":
+            return json.dumps([[{"tag_name": "v1.2.4", "draft": False}]])
+        return ""
+
+    monkeypatch.setattr(release_tools, "command", command)
+    monkeypatch.setattr(release_tools.subprocess, "run", lambda *a, **kw: None)
+    with pytest.raises(ValueError, match="after published"):
+        release_tools.guard()
+
+
+def test_packaging_fixture_uses_real_spawned_processing():
+    packaging_smoke.smoke(check_inference=False)

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,373 @@
+import fcntl
+import json
+import sqlite3
+import threading
+import time
+import wave
+from pathlib import Path
+
+import pytest
+
+from crowbarr import inference, processor, service
+from crowbarr.config import ConfigStore, Settings
+from crowbarr.db import Database, StaleJob
+from crowbarr.subtitles import Word
+
+
+def test_repeated_crashes_exhaust_attempts_and_clear_progress(tmp_path):
+    db = Database(tmp_path / "crowbarr.db")
+    identifier = db.enqueue("/media/movie.mkv", "one", None, 0)
+    for attempt in range(1, 4):
+        job = db.claim()
+        assert job["attempts"] == attempt
+        db.update(identifier, progress_current=20, progress_total=30, cached=1)
+        db.recover(max_attempts=3)
+    recovered = db.get(identifier)
+    assert recovered["state"] == "failed"
+    assert recovered["attempts"] == 3
+    assert all(recovered[key] is None for key in ("progress_current", "progress_total", "cached", "started"))
+    assert db.claim() is None
+    db.recover(max_attempts=3)
+    with db.connect() as connection:
+        assert connection.execute("SELECT COUNT(*) FROM history").fetchone()[0] == 1
+
+
+def test_restart_honours_pending_cancellation(tmp_path):
+    db = Database(tmp_path / "crowbarr.db")
+    identifier = db.enqueue("/media/movie.mkv", "one", None, 0)
+    db.claim()
+    db.cancel(identifier)
+    db.recover()
+    assert db.get(identifier)["state"] == "cancelled"
+    assert db.claim() is None
+
+
+@pytest.mark.parametrize("replace", ["revision", "directive", "recovery"])
+def test_old_worker_cannot_change_replacement_request(tmp_path, replace):
+    db = Database(tmp_path / "crowbarr.db")
+    identifier = db.enqueue("/media/movie.mkv", "one", None, 0)
+    job = db.claim()
+    worker = Database(db.path)
+    worker.bind_worker(job)
+    worker.update(identifier, stage="Recognizing dialogue", progress_current=10, progress_total=40)
+    if replace == "revision":
+        db.enqueue(job["media"], "two", None, 0)
+    elif replace == "directive":
+        db.direct(identifier, "generate")
+    else:
+        db.recover()
+    expected = db.get(identifier)
+    for values in ({"progress_current": 30}, {"state": "superseded"}, {"state": "completed"}):
+        with pytest.raises(StaleJob):
+            worker.update(identifier, **values)
+    with pytest.raises(StaleJob):
+        worker.register_artifact(job["media"], "/media/movie.crowbarr.en.srt", "old", identifier)
+    assert not db.update(identifier, expected_generation=job["generation"], state="failed")
+    assert db.get(identifier) == expected
+    new_job = db.claim()
+    assert new_job["generation"] > job["generation"]
+
+
+@pytest.mark.parametrize("outcome", ["result", "review", "error"])
+def test_subprocess_completion_cannot_overwrite_new_request(tmp_path, monkeypatch, outcome):
+    db = Database(tmp_path / "crowbarr.db")
+    identifier = db.enqueue("/media/movie.mkv", "one", None, 0, origin="manual")
+    job = db.claim()
+    monkeypatch.setattr(service.os, "setsid", lambda: None)
+
+    def process(*args):
+        db.direct(identifier, "generate")
+        if outcome == "review":
+            raise service.ReviewRequired("Synthetic review")
+        if outcome == "error":
+            raise ValueError("Synthetic failure")
+        return {"state": "completed", "report": "{}"}
+
+    monkeypatch.setattr(processor, "process", process)
+    service.run_job(str(tmp_path), job, Settings().model_dump())
+    assert db.get(identifier)["state"] == "queued"
+    assert db.get(identifier)["directive"] == "generate"
+    assert not (tmp_path / "reports" / f"{identifier}.json").exists()
+
+
+def test_legacy_migration_preserves_ownership_history_and_is_idempotent(tmp_path):
+    path = tmp_path / "crowbarr.db"
+    db = Database(path)
+    first = db.enqueue("/media/movie.mkv", "one", None, 0)
+    output = "/media/movie.crowbarr.en.srt"
+    # Reconstruct the pre-deduplication schema and report-only ownership.
+    with db.connect() as connection:
+        connection.execute("DROP INDEX jobs_media")
+        connection.execute("ALTER TABLE jobs DROP COLUMN generation")
+        connection.execute(
+            "UPDATE jobs SET state='completed',output=?,report=? WHERE id=?",
+            (output, json.dumps({"output_sha256": "legacy-digest"}), first),
+        )
+        connection.execute(
+            "INSERT INTO jobs(media,signature,state,created,updated,ready) VALUES (?,?,?,0,1,0)",
+            ("/media/movie.mkv", "two", "review"),
+        )
+    for _ in range(2):
+        migrated = Database(path)
+        assert migrated.owns_output("/media/movie.mkv", output, "legacy-digest")
+        with migrated.connect() as connection:
+            rows = connection.execute("SELECT * FROM jobs").fetchall()
+            assert len(rows) == 1
+            assert rows[0]["state"] == "review"
+            assert rows[0]["generation"] == 0
+            history = connection.execute("SELECT * FROM history").fetchall()
+            assert len(history) == 1
+            assert history[0]["state"] == "completed"
+            assert history[0]["output"] == output
+            assert history[0]["job_id"] is None
+
+
+def test_failed_legacy_migration_rolls_back_schema_and_preserved_records(tmp_path):
+    path = tmp_path / "crowbarr.db"
+    db = Database(path)
+    db.enqueue("/media/movie.mkv", "one", None, 0)
+    with db.connect() as connection:
+        connection.execute("DROP INDEX jobs_media")
+        connection.execute("ALTER TABLE jobs DROP COLUMN generation")
+        connection.execute(
+            "UPDATE jobs SET state='completed',output='/media/movie.crowbarr.en.srt',report=?",
+            (json.dumps({"output_sha256": "legacy-digest"}),),
+        )
+        connection.execute(
+            "INSERT INTO jobs(media,signature,state,created,updated,ready) VALUES (?,?,?,0,1,0)",
+            ("/media/movie.mkv", "two", "review"),
+        )
+        connection.execute(
+            "CREATE TRIGGER stop_migration BEFORE DELETE ON jobs BEGIN "
+            "SELECT RAISE(ABORT, 'Synthetic migration failure'); END"
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        Database(path)
+    with db.connect() as connection:
+        assert connection.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 2
+        assert connection.execute("SELECT COUNT(*) FROM artifacts").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM history").fetchone()[0] == 0
+        assert "generation" not in {row[1] for row in connection.execute("PRAGMA table_info(jobs)")}
+
+
+@pytest.mark.parametrize(
+    "damaged",
+    [
+        "{",
+        '{"words":[{}],"issues":[]}',
+        '{"words":[{"start":"bad","end":1,"text":"hello","probability":1}],"issues":[]}',
+    ],
+)
+def test_corrupt_chunk_is_rebuilt_without_repeating_valid_chunks(tmp_path, monkeypatch, damaged):
+    audio = tmp_path / "audio.wav"
+    with wave.open(str(audio), "wb") as output:
+        output.setparams((1, 2, 10, 0, "NONE", "not compressed"))
+        output.writeframes(b"\0\0" * 10 * 600)
+    checkpoint = tmp_path / "transcript.parts"
+    checkpoint.mkdir()
+    valid = json.dumps({"words": [vars(Word(1, 2, "saved", 0.9))], "issues": []})
+    (checkpoint / "0.json").write_text(valid)
+    (checkpoint / "1.json").write_text(damaged)
+    calls, progress = [], []
+
+    def recognize(*args):
+        calls.append(True)
+        return [Word(3, 4, "rebuilt", 0.9)], []
+
+    recognize.progress = lambda current, total: progress.append((current, total))
+    monkeypatch.setattr(inference, "transcribe", recognize)
+    words, issues = inference.transcribe_bounded(audio, Settings(), tmp_path, checkpoint)
+    assert not issues
+    assert [w.text for w in words] == ["saved", "rebuilt"]
+    assert len(calls) == 1
+    assert progress[-1] == (600, 600)
+    assert (checkpoint / "0.json").read_text() == valid
+    inference.transcribe_bounded(audio, Settings(), tmp_path, checkpoint)
+    assert len(calls) == 1
+
+
+def test_shutdown_uses_one_deadline_and_keeps_lock_for_live_threads(tmp_path):
+    store = ConfigStore(tmp_path)
+    instance = service.Service(store, Database(tmp_path / "crowbarr.db"))
+    instance.lock_file = (tmp_path / "service.lock").open("a")
+    fcntl.flock(instance.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    release = threading.Event()
+    instance.threads = [threading.Thread(target=release.wait, daemon=True) for _ in range(2)]
+    for thread in instance.threads:
+        thread.start()
+    try:
+        started = time.monotonic()
+        instance.close(timeout=0.05)
+        assert time.monotonic() - started < 0.2
+        assert instance.stop_event.is_set()
+        with (tmp_path / "service.lock").open("a") as contender:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        release.set()
+        for thread in instance.threads:
+            thread.join(timeout=1)
+    deadline = time.monotonic() + 1
+    while not instance.lock_file.closed and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert instance.lock_file.closed
+
+
+def test_main_initializes_frozen_workers_before_argument_parsing(monkeypatch):
+    import sys
+
+    import uvicorn
+
+    from crowbarr import __main__
+
+    events = []
+    monkeypatch.setattr(__main__.multiprocessing, "freeze_support", lambda: events.append("freeze"))
+    monkeypatch.setattr(sys, "argv", ["crowbarr", "--port", "8450"])
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: events.append(kwargs))
+    __main__.main()
+    assert events[0] == "freeze"
+    assert events[1]["port"] == 8450
+    assert events[1]["timeout_graceful_shutdown"] == 5
+
+
+@pytest.mark.parametrize("interruption", ["stop", "settings", "replacement", "cancel"])
+def test_active_worker_interruption_preserves_retry_and_new_request(tmp_path, monkeypatch, interruption):
+    from types import SimpleNamespace
+
+    store = ConfigStore(tmp_path)
+    store.save(Settings(max_attempts=1))
+    db = Database(tmp_path / "crowbarr.db")
+    identifier = db.enqueue("/media/movie.mkv", "one", None, 0, origin="manual")
+    instance = service.Service(store, db)
+
+    class ImmediateEvent(threading.Event):
+        def wait(self, timeout=None):
+            return self.is_set()
+
+    instance.stop_event = ImmediateEvent()
+
+    class Child:
+        pid = 123456
+        alive = True
+        interrupted = False
+
+        def start(self):
+            pass
+
+        def is_alive(self):
+            return self.alive
+
+        def join(self, timeout=None):
+            if self.interrupted:
+                return
+            self.interrupted = True
+            if interruption == "settings":
+                store.save(Settings(model="base", max_attempts=1))
+            elif interruption == "replacement":
+                db.direct(identifier, "generate")
+            elif interruption == "cancel":
+                db.cancel(identifier)
+            else:
+                instance.stop_event.set()
+
+        def terminate(self):
+            self.alive = False
+
+        def close(self):
+            instance.stop_event.set()
+
+    child = Child()
+    signals = []
+
+    def stop_group(pid, sig):
+        signals.append(sig)
+        child.terminate()
+
+    monkeypatch.setattr(
+        service.multiprocessing, "get_context", lambda method: SimpleNamespace(Process=lambda **kw: child)
+    )
+    monkeypatch.setattr(service, "resource_snapshot", lambda: {})
+    monkeypatch.setattr(service, "gate", lambda *args: "")
+    monkeypatch.setattr(service.os, "killpg", stop_group)
+    instance.worker()
+    job = db.get(identifier)
+    assert not child.alive
+    assert signals == [service.signal.SIGTERM, service.signal.SIGKILL]
+    assert instance.child_pid is None
+    if interruption == "replacement":
+        assert job["state"] == "queued"
+        assert job["directive"] == "generate"
+        assert job["attempts"] == 0
+    elif interruption == "cancel":
+        assert job["state"] == "cancelled"
+    else:
+        assert job["state"] == "retry"
+        assert job["attempts"] == 0
+        assert job["origin"] == "manual"
+        assert job["priority"] == 100
+        assert db.claim()["attempts"] == 1
+
+
+def test_open_event_stream_does_not_prevent_server_shutdown(tmp_path, monkeypatch):
+    import asyncio
+    import socket
+
+    import httpx
+    import uvicorn
+
+    from crowbarr.app import create_app
+
+    app = create_app(tmp_path)
+    instance = app.state.service
+    closed = threading.Event()
+    monkeypatch.setattr(instance, "start", lambda: None)
+    monkeypatch.setattr(instance, "close", closed.set)
+
+    async def exercise():
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", 0))
+            server = uvicorn.Server(
+                uvicorn.Config(
+                    app,
+                    timeout_graceful_shutdown=0.1,
+                    log_level="critical",
+                    lifespan="on",
+                )
+            )
+            task = asyncio.create_task(server.serve(sockets=[listener]))
+            try:
+                async with asyncio.timeout(5):
+                    while not server.started:
+                        await asyncio.sleep(0.01)
+                    async with httpx.AsyncClient(trust_env=False) as client:
+                        url = f"http://127.0.0.1:{listener.getsockname()[1]}/api/events"
+                        async with client.stream(
+                            "GET", url, headers={"X-Api-Key": app.state.store.token}
+                        ) as response:
+                            assert response.status_code == 200
+                            async for line in response.aiter_lines():
+                                if line.startswith("event: status"):
+                                    break
+                            server.should_exit = True
+                            await task
+                            assert closed.is_set()
+            finally:
+                server.should_exit = True
+                if not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+
+    asyncio.run(exercise())
+
+
+def test_relative_app_data_path_is_fixed_before_working_directory_changes(tmp_path, monkeypatch):
+    from crowbarr.app import create_app
+
+    monkeypatch.chdir(tmp_path)
+    app = create_app(Path("state"), background=False)
+    monkeypatch.chdir(tmp_path.parent)
+    assert app.state.store.directory == tmp_path / "state"
+    app.state.store.save(Settings(paused=True))
+    assert ConfigStore(tmp_path / "state").get().paused
+    identifier = app.state.db.enqueue("/media/movie.mkv", "one", None, 0)
+    assert Database(tmp_path / "state" / "crowbarr.db").get(identifier)


### PR DESCRIPTION
Crowbarr's manual deployments did not provide a release-only managed update path, and restart/native-upgrade failures could lose apparent progress or select different data directories. This release adds public Portainer GitOps manifests with persistent host storage, fixes interrupted/stale job handling, and retains native installation settings with optional daily updates.

Container and native builds include the documented optional refinement dependencies. Publication now depends on tests and clean packaged-runtime checks before advancing release channels. The audit policy remains unchanged.

Installation, NAS, migration, backup and rollback instructions describe normal host settings and dashboard configuration. The generated environment example does not pin users unintentionally, and release documentation links are tested.

Validation: full local suite passed 217 tests before final follow-up checks; focused packaging/restart/Compose checks pass. GitHub CI validates supported Python versions, and the release workflow verifies actual CPU, CUDA and native packages before publication. TrueNAS migration and real GPU verification follow using the published release, with no private application patches.
