### PR TITLE
Record why WhisperX alignment fell back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,13 @@ release with split versioning requeues nothing.
 `APPLICATION_VERSION`. Identifies a published release. Changing it alone never
 re-audits anything.
 
+### 0.3.8
+
+- WhisperX alignment failures record their cause in the service log. On an NVIDIA
+  install where CUDA alignment fails and refinement retries on the CPU, the report
+  said only that loading failed, which left no way to find out why. Reports and the
+  dashboard still carry no exception detail.
+
 ### 0.3.7
 
 - Settings identifies unavailable CUDA and WhisperX runtimes before new selections

--- a/crowbarr/inference.py
+++ b/crowbarr/inference.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import logging
 import math
 import textwrap
 import wave
@@ -11,6 +12,8 @@ from pathlib import Path
 from .config import Settings
 from .media import ReviewRequired
 from .subtitles import Cue, Passage, Word, alignment_text
+
+log = logging.getLogger(__name__)
 
 _resident = None
 _resident_key = None
@@ -149,6 +152,9 @@ def _align_attempt(audio, passages, settings, cache, backend, np, whisperx):
             language_code=settings.language, device=backend, model_dir=str(cache / "alignment")
         )
     except Exception:
+        # The reported reason stays free of exception payloads. The cause still has to
+        # reach the log, or a backend that never works cannot be diagnosed.
+        log.warning("WhisperX %s alignment model loading failed", backend, exc_info=True)
         raise _AlignmentFailure(f"WhisperX {backend.upper()} alignment model loading failed") from None
     cues, issues = [], []
     with wave.open(str(audio), "rb") as stream:
@@ -171,6 +177,7 @@ def _align_attempt(audio, passages, settings, cache, backend, np, whisperx):
                     interpolate_method="ignore",
                 )
             except Exception:
+                log.warning("WhisperX %s alignment execution failed", backend, exc_info=True)
                 raise _AlignmentFailure(f"WhisperX {backend.upper()} alignment execution failed") from None
             words = result.get("word_segments", [])
             scored = [w for w in words if all(k in w for k in ("start", "end", "score"))]

--- a/crowbarr/version.py
+++ b/crowbarr/version.py
@@ -9,5 +9,5 @@ What each value means for an installation is recorded in ``CHANGELOG.md``, not h
 Changing either without an entry there fails ``tests/test_release.py``.
 """
 
-APPLICATION_VERSION = "0.3.7"
+APPLICATION_VERSION = "0.3.8"
 AUDIT_POLICY_VERSION = "0.3.4"

--- a/tests/test_alignment_fallback.py
+++ b/tests/test_alignment_fallback.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import sys
 import wave
@@ -119,6 +120,17 @@ def test_cuda_failure_retries_all_passages_on_cpu(backend, alignment_input, tmp_
     assert inference.align.runtime["backend"] == "cpu"
     assert inference.align.runtime["status"] == "completed"
     assert SECRET not in json.dumps([issues, inference.align.runtime])
+
+
+def test_alignment_failure_cause_reaches_the_log(backend, alignment_input, tmp_path, caplog):
+    backend.failures.add(("cuda", "load"))
+    with caplog.at_level(logging.WARNING, logger="crowbarr.inference"):
+        cues, issues = inference.align(*alignment_input, Settings(device="cuda"), tmp_path)
+    assert cues, "the CPU retry still has to produce cues"
+    # The operator needs the cause somewhere. The report and the dashboard are not it.
+    assert SECRET not in json.dumps([issues, inference.align.runtime])
+    logged = [record for record in caplog.records if "alignment model loading failed" in record.message]
+    assert logged and all(record.exc_info for record in logged)
 
 
 @pytest.mark.parametrize("failure", ["load", 1, 2])


### PR DESCRIPTION
On a T400 with driver 550, transcription runs on CUDA but WhisperX alignment fails to load its model there and retries on the CPU. The retry works and the job report names the fallback, but the cause is discarded by `raise ... from None` and `inference.py` logs nothing, so there is no way to tell whether the card is too small, the driver is wrong, or the rebased CUDA image is at fault.

Observed on a real install running the published `0.3.7-cuda` image:

```
alignment_runtime:
  requested_backend: cuda
  backend: cpu
  fallback_reason: WhisperX CUDA alignment model loading failed
  status: completed
```

This logs the original exception before raising the sanitised failure, for both the model load and the alignment execution. Reports, issues and the dashboard are unchanged and still carry no exception payload. A regression test asserts the cause reaches the log while the report stays clean.